### PR TITLE
Allow custom read statuses

### DIFF
--- a/addon/chrome/content/preferences.css
+++ b/addon/chrome/content/preferences.css
@@ -1,7 +1,12 @@
-/* tr:nth-child(even) {
-	background-color: blue;
-} */
+/* Normally need to restart Zotero for these to take effect */
 
-/* * {
-	color: red;
-} */
+/* Add, save, reset buttons */
+table > button {
+	margin: 5px;
+}
+
+/* Up, down, delete buttons in rows */
+td > button {
+	margin-left: 2px;
+	margin-right: 2px;
+}

--- a/addon/chrome/content/preferences.css
+++ b/addon/chrome/content/preferences.css
@@ -1,0 +1,7 @@
+/* tr:nth-child(even) {
+	background-color: blue;
+} */
+
+/* * {
+	color: red;
+} */

--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -1,34 +1,45 @@
 <linkset>
 	<html:link rel="localization" href="__addonRef__-preferences.ftl" />
+	<html:link rel="stylesheet" href="chrome://__addonRef__/content/preferences.css" />
 </linkset>
-<vbox
-	id="zotero-prefpane-__addonRef__"
-	onload="Zotero.__addonInstance__.hooks.onPrefsEvent('load', {window})"
->
+<vbox id="zotero-prefpane-__addonRef__" onload="Zotero.__addonInstance__.hooks.onPrefsLoad(window)">
 	<groupbox>
 		<label>
 			<html:h2 data-l10n-id="pref-title"></html:h2>
 		</label>
-		<checkbox
-			id="zotero-prefpane-__addonRef__-show-icons"
-			preference="extensions.zotero.__addonRef__.show-icons"
-			data-l10n-id="pref-show-icons"
-		/>
-		<checkbox
-			id="zotero-prefpane-__addonRef__-enable-keyboard-shortcuts"
+		<checkbox id="zotero-prefpane-__addonRef__-show-icons" preference="extensions.zotero.__addonRef__.show-icons"
+			data-l10n-id="pref-show-icons" />
+		<checkbox id="zotero-prefpane-__addonRef__-enable-keyboard-shortcuts"
 			preference="extensions.zotero.__addonRef__.enable-keyboard-shortcuts"
-			data-l10n-id="pref-enable-keyboard-shortcuts"
-		/>
-		<checkbox
-			id="zotero-prefpane-__addonRef__-label-new-items"
-			preference="extensions.zotero.__addonRef__.label-new-items"
-			data-l10n-id="pref-label-new-items"
-		/>
+			data-l10n-id="pref-enable-keyboard-shortcuts" />
+		<checkbox id="zotero-prefpane-__addonRef__-label-new-items"
+			preference="extensions.zotero.__addonRef__.label-new-items" data-l10n-id="pref-label-new-items" />
 	</groupbox>
-</vbox>
-<vbox>
-	<html:label
-		data-l10n-id="pref-help"
-		data-l10n-args='{"time": "__buildTime__","name": "__addonName__","version":"__buildVersion__"}'
-	></html:label>
+	<groupbox>
+		<label>
+			<html:h2 data-l10n-id="pref-statuslabeltable-title"></html:h2>
+		</label>
+		<html:table>
+			<html:thead>
+				<html:tr>
+					<!-- <html:th data-l10n-id="pref-statuslabeltable-header-number"></html:th> -->
+					<html:th data-l10n-id="pref-statuslabeltable-header-statusicon"></html:th>
+					<html:th data-l10n-id="pref-statuslabeltable-header-statusname"></html:th>
+					<html:th data-l10n-id="pref-statuslabeltable-header-reorder"></html:th>
+				</html:tr>
+			</html:thead>
+			<html:tbody id="statusnames-table-body">
+			</html:tbody>
+			<html:button id="statusnames-save-add" onclick="Zotero.__addonInstance__.hooks.addTableRow(window)">Add
+			</html:button>
+			<br />
+			<html:button id="statusnames-save-button" onclick="Zotero.__addonInstance__.hooks.saveTable(window)">Save
+			</html:button>
+			<html:button id="statusnames-reset-button" onclick="Zotero.__addonInstance__.hooks.resetTable(window)">Reset
+				to Default</html:button>
+		</html:table>
+	</groupbox>
+
+	<html:label data-l10n-id="pref-help"
+		data-l10n-args='{"time": "__buildTime__","name": "__addonName__","version":"__buildVersion__"}'></html:label>
 </vbox>

--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -30,13 +30,13 @@
 			</html:thead>
 			<html:tbody id="statusnames-table-body">
 			</html:tbody>
-			<html:button id="statusnames-save-add" onclick="Zotero.__addonInstance__.hooks.addTableRow(window)">Add
-			</html:button>
+			<html:button id="statusnames-save-add" onclick="Zotero.__addonInstance__.hooks.addTableRow(window)"
+				data-l10n-id="pref-statuslabeltable-button-add" />
 			<br />
-			<html:button id="statusnames-save-button" onclick="Zotero.__addonInstance__.hooks.saveTable(window)">Save
-			</html:button>
-			<html:button id="statusnames-reset-button" onclick="Zotero.__addonInstance__.hooks.resetTable(window)">Reset
-				to Default</html:button>
+			<html:button id="statusnames-save-button" onclick="Zotero.__addonInstance__.hooks.saveTable(window)"
+				data-l10n-id="pref-statuslabeltable-button-save" />
+			<html:button id="statusnames-reset-button" onclick="Zotero.__addonInstance__.hooks.resetTable(window)"
+				data-l10n-id="pref-statuslabeltable-button-reset" />
 		</html:table>
 	</groupbox>
 

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -1,4 +1,4 @@
-pref-title = Zotero Reading List
+pref-title = Zotero Reading List Settings
 pref-show-icons =
     .label = Show icons along with an item's read status
 pref-enable-keyboard-shortcuts =
@@ -6,3 +6,8 @@ pref-enable-keyboard-shortcuts =
 pref-label-new-items =
     .label = Automatically label items as "New" when you add them to Zotero
 pref-help = { $name } Build { $version } { $time }
+pref-statuslabeltable-title = Custom Reading Statuses
+pref-statuslabeltable-header-number = Number
+pref-statuslabeltable-header-statusicon = Status Icon
+pref-statuslabeltable-header-statusname = Status Name
+pref-statuslabeltable-header-reorder = Reorder

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -11,3 +11,6 @@ pref-statuslabeltable-header-number = Number
 pref-statuslabeltable-header-statusicon = Status Icon
 pref-statuslabeltable-header-statusname = Status Name
 pref-statuslabeltable-header-reorder = Reorder
+pref-statuslabeltable-button-add = Add New Status
+pref-statuslabeltable-button-save = Save
+pref-statuslabeltable-button-reset = Reset to Default

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,9 @@
+import {STATUS_NAME_LIST_PREF, STATUS_ICON_LIST_PREF, DEFAULT_STATUS_NAMES, DEFAULT_STATUS_ICONS} from "./modules/overlay";
 import ZoteroReadingList from "./modules/overlay";
 import { config } from "../package.json";
 import { initLocale } from "./utils/locale";
 import { createZToolkit } from "./utils/ztoolkit";
+import { getPref, setPref } from "./utils/prefs";
 
 let zoteroReadingList: ZoteroReadingList;
 
@@ -38,6 +40,101 @@ async function onMainWindowUnload(win: Window): Promise<void> {
 	addon.data.dialog?.window?.close();
 }
 
+function onPrefsLoad(window:Window) {
+	const tableBody = window.document.getElementById("statusnames-table-body");
+	for (const row of createStatusNamesTableRows()){
+		tableBody?.append(row)
+	}
+}
+
+function addTableRow(window:Window) {
+	const tableBody = window.document.getElementById("statusnames-table-body");
+	tableBody?.append(createTableRow("", ""));
+}
+
+function resetTable(window:Window) {
+	const tableRows = window.document.getElementById("statusnames-table-body")?.children;
+	if (tableRows != undefined){
+		for (let i=tableRows.length-1; i >= 0; i--){
+			tableRows[i].remove();
+		}
+	}
+	setPref(STATUS_NAME_LIST_PREF, DEFAULT_STATUS_NAMES.join(";"));
+	setPref(STATUS_ICON_LIST_PREF, DEFAULT_STATUS_ICONS.join(";"));
+	onPrefsLoad(window);
+}
+
+function saveTable(window:Window) {
+	const tableRows = window.document.getElementById("statusnames-table-body")?.children;
+	const names: string[] = [];
+	const icons: string[] = [];
+	if (tableRows != undefined){
+		for (let i=0; i < tableRows.length; i++){
+			icons.push((tableRows[i].children[0].firstChild as HTMLInputElement).value);
+			names.push((tableRows[i].children[1].firstChild as HTMLInputElement).value);
+		}
+	}
+	setPref(STATUS_NAME_LIST_PREF, names.join(";"));
+	setPref(STATUS_ICON_LIST_PREF, icons.join(";"));
+}
+
+function createElement(elementName: string){
+	return document.createElementNS("http://www.w3.org/1999/xhtml", elementName);
+}
+
+function moveElementHigher(element: HTMLElement){
+	if (element != element.parentElement?.firstChild){
+		element.parentElement?.insertBefore(element, element.previousSibling);
+	}
+}
+
+function moveElementLower(element: HTMLElement){
+	if (element.nextSibling){
+		element.parentElement?.insertBefore(element, element.nextSibling?.nextSibling);
+	}
+}
+
+function createStatusNamesTableRows(){
+	const statusNames = (getPref(STATUS_NAME_LIST_PREF) as string).split(';');
+	const statusIcons = (getPref(STATUS_ICON_LIST_PREF) as string).split(';');
+	return statusNames.map((statusName, index) => createTableRow(statusIcons[index], statusName));
+}
+
+function createTableRow(icon: string, name: string){
+	const row = createElement("html:tr");
+
+	const iconRow = createElement("html:td");
+	const iconInput = createElement("html:input") as HTMLInputElement;
+	iconInput.type = "text";
+	iconInput.value = icon;
+	iconRow.append(iconInput);
+
+	const nameRow = createElement("html:td");
+	const nameInput = createElement("html:input") as HTMLInputElement;
+	nameInput.type = "text";
+	nameInput.value = name;
+	nameRow.append(nameInput);
+
+	const settings = createElement("html:td");
+	const upButton = createElement("html:button");
+	const downButton = createElement("html:button");
+	const binButton = createElement("html:button");
+	upButton.textContent = "⬆";
+	downButton.textContent = "⬇";
+	binButton.textContent = "🗑";
+	upButton.onclick = () => { moveElementHigher(row) };
+	downButton.onclick = () => { moveElementLower(row) };
+	binButton.onclick = () => { row.remove() };
+	settings.append(upButton);
+	settings.append(downButton);
+	settings.append(binButton);
+
+	row.append(iconRow);
+	row.append(nameRow);
+	row.append(settings);
+	return row;
+}
+
 function onShutdown(): void {
 	ztoolkit.unregisterAll();
 	addon.data.dialog?.window?.close();
@@ -51,4 +148,8 @@ export default {
 	onShutdown,
 	onMainWindowLoad,
 	onMainWindowUnload,
+	onPrefsLoad,
+	addTableRow,
+	saveTable,
+	resetTable,
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import {STATUS_NAME_LIST_PREF, STATUS_ICON_LIST_PREF, DEFAULT_STATUS_NAMES, DEFAULT_STATUS_ICONS} from "./modules/overlay";
+import {STATUS_NAME_AND_ICON_LIST_PREF, DEFAULT_STATUS_NAMES, DEFAULT_STATUS_ICONS, prefStringToList, listToPrefString} from "./modules/overlay";
 import ZoteroReadingList from "./modules/overlay";
 import { config } from "../package.json";
 import { initLocale } from "./utils/locale";
@@ -59,8 +59,7 @@ function resetTable(window:Window) {
 			tableRows[i].remove();
 		}
 	}
-	setPref(STATUS_NAME_LIST_PREF, DEFAULT_STATUS_NAMES.join(";"));
-	setPref(STATUS_ICON_LIST_PREF, DEFAULT_STATUS_ICONS.join(";"));
+	setPref(STATUS_NAME_AND_ICON_LIST_PREF, listToPrefString(DEFAULT_STATUS_NAMES, DEFAULT_STATUS_ICONS));
 	onPrefsLoad(window);
 }
 
@@ -74,8 +73,7 @@ function saveTable(window:Window) {
 			names.push((tableRows[i].children[1].firstChild as HTMLInputElement).value);
 		}
 	}
-	setPref(STATUS_NAME_LIST_PREF, names.join(";"));
-	setPref(STATUS_ICON_LIST_PREF, icons.join(";"));
+	setPref(STATUS_NAME_AND_ICON_LIST_PREF, listToPrefString(names, icons));
 }
 
 function createElement(elementName: string){
@@ -95,8 +93,7 @@ function moveElementLower(element: HTMLElement){
 }
 
 function createStatusNamesTableRows(){
-	const statusNames = (getPref(STATUS_NAME_LIST_PREF) as string).split(';');
-	const statusIcons = (getPref(STATUS_ICON_LIST_PREF) as string).split(';');
+	const [statusNames, statusIcons] = prefStringToList(getPref(STATUS_NAME_AND_ICON_LIST_PREF) as string);
 	return statusNames.map((statusName, index) => createTableRow(statusIcons[index], statusName));
 }
 

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -2,42 +2,21 @@ import { MenuitemOptions } from "zotero-plugin-toolkit/dist/managers/menu";
 import { config } from "../../package.json";
 import { getString } from "../utils/locale";
 import { patch as $patch$ } from "../utils/patcher";
+import {setPref, getPref, initialiseDefaultPref, getPrefGlobalName} from "../utils/prefs";
 
 const READ_STATUS_COLUMN_ID = "readstatus";
 const READ_STATUS_COLUMN_NAME = "Read Status";
 const READ_STATUS_EXTRA_FIELD = "Read_Status";
 const READ_DATE_EXTRA_FIELD = "Read_Status_Date";
-const STATUS_NAMES = ["New", "To Read", "In Progress", "Read", "Not Reading"];
-const STATUS_ICONS = [
-	"\u2B50",
-	"\uD83D\uDCD9",
-	"\uD83D\uDCD6",
-	"\uD83D\uDCD7",
-	"\uD83D\uDCD5",
-];
 
-const SHOW_ICONS_PREF = getGlobalPrefName("show-icons");
-const LABEL_NEW_ITEMS_PREF = getGlobalPrefName("label-new-items");
-const ENABLE_KEYBOARD_SHORTCUTS_PREF = getGlobalPrefName(
-	"enable-keyboard-shortcuts",
-);
+export const DEFAULT_STATUS_NAMES = ["New", "To Read", "In Progress", "Read", "Not Reading"]
+export const DEFAULT_STATUS_ICONS = ["⭐","📙","📖","📗","📕"]
 
-function getGlobalPrefName(preferenceName: string) {
-	return `${config.prefsPrefix}.${preferenceName}`;
-}
-
-function getPref(preferenceName: string) {
-	return Zotero.Prefs.get(preferenceName, true);
-}
-
-function initialiseDefaultPref(
-	preferenceName: string,
-	defaultValue: boolean | string | number,
-) {
-	if (getPref(preferenceName) === undefined) {
-		Zotero.Prefs.set(preferenceName, defaultValue, true);
-	}
-}
+export const SHOW_ICONS_PREF = "show-icons";
+export const LABEL_NEW_ITEMS_PREF = "label-new-items";
+export const ENABLE_KEYBOARD_SHORTCUTS_PREF = "enable-keyboard-shortcuts";
+export const STATUS_NAME_LIST_PREF = "status-name-list";
+export const STATUS_ICON_LIST_PREF = "status-icon-list";
 
 function isString(argument: any): argument is string {
 	return typeof argument == "string";
@@ -111,24 +90,6 @@ function clearItemExtraProperty(item: Zotero.Item, fieldName: string) {
 		"extra",
 		removeFieldValueFromExtraData(item.getField("extra"), fieldName),
 	);
-}
-
-/**
- * Format name of status to localise text and include icon if enabled.
- * @param {string} statusName - The name of the status.
- * @returns {String} values - Name of the status, possibly prefixed with the corresponding icon.
- */
-function formatStatusName(statusName: string): string {
-	if (getPref(SHOW_ICONS_PREF)) {
-		const statusIndex = STATUS_NAMES.indexOf(statusName);
-		const localisedStatus = getString(
-			`status-${statusName.toLowerCase().replace(" ", "_")}`,
-		);
-		if (statusIndex > -1) {
-			return `${STATUS_ICONS[statusIndex]} ${localisedStatus}`;
-		}
-	}
-	return statusName;
 }
 
 function getItemReadStatus(item: Zotero.Item) {
@@ -205,9 +166,14 @@ export default class ZoteroReadingList {
 	itemAddedListenerID?: string;
 	itemTreeReadStatusColumnId?: string | false;
 	preferenceUpdateObservers?: symbol[];
+	statusNames: string[];
+	statusIcons: string[];
 
 	constructor() {
 		this.initialiseDefaultPreferences();
+		this.statusNames = this.prefStringToList(getPref(STATUS_NAME_LIST_PREF));
+		this.statusIcons = this.prefStringToList(getPref(STATUS_ICON_LIST_PREF));
+
 		void this.addReadStatusColumn();
 		this.addPreferencesMenu();
 		this.addRightClickMenuPopup();
@@ -236,12 +202,22 @@ export default class ZoteroReadingList {
 		initialiseDefaultPref(SHOW_ICONS_PREF, true);
 		initialiseDefaultPref(ENABLE_KEYBOARD_SHORTCUTS_PREF, true);
 		initialiseDefaultPref(LABEL_NEW_ITEMS_PREF, false);
+		initialiseDefaultPref(STATUS_NAME_LIST_PREF, this.listToPrefString(DEFAULT_STATUS_NAMES));
+		initialiseDefaultPref(STATUS_ICON_LIST_PREF, this.listToPrefString(DEFAULT_STATUS_ICONS));
+	}
+
+	prefStringToList(prefString: string | number | boolean | undefined){
+		return (prefString as string).split(';');
+	}
+
+	listToPrefString(stringList: string[]){
+		return stringList.join(';');
 	}
 
 	addPreferenceUpdateObservers() {
 		this.preferenceUpdateObservers = [
 			Zotero.Prefs.registerObserver(
-				ENABLE_KEYBOARD_SHORTCUTS_PREF,
+				getPrefGlobalName(ENABLE_KEYBOARD_SHORTCUTS_PREF),
 				(value: boolean) => {
 					if (value) {
 						this.addKeyboardShortcutListener();
@@ -252,13 +228,28 @@ export default class ZoteroReadingList {
 				true,
 			) as symbol,
 			Zotero.Prefs.registerObserver(
-				LABEL_NEW_ITEMS_PREF,
+				getPrefGlobalName(LABEL_NEW_ITEMS_PREF),
 				(value: boolean) => {
 					if (value) {
 						this.addNewItemLabeller();
 					} else {
 						this.removeNewItemLabeller();
 					}
+				},
+				true,
+			) as symbol,
+			Zotero.Prefs.registerObserver(
+				getPrefGlobalName(STATUS_NAME_LIST_PREF),
+				(value: string) => {
+					this.statusNames = this.prefStringToList(value);
+					this.statusIcons = this.prefStringToList(getPref(STATUS_ICON_LIST_PREF));
+					this.removeRightClickMenu();
+					this.addRightClickMenuPopup();
+					this.removeKeyboardShortcutListener();
+					this.addKeyboardShortcutListener();
+					this.removeReadStatusColumn();
+					void this.addReadStatusColumn();
+					// fix: this returns undefined for the icon if we add a new one
 				},
 				true,
 			) as symbol,
@@ -275,6 +266,7 @@ export default class ZoteroReadingList {
 	}
 
 	async addReadStatusColumn() {
+		const formatStatusName = (statusName: string) => this.formatStatusName(statusName);
 		this.itemTreeReadStatusColumnId =
 			await Zotero.ItemTreeManager.registerColumns({
 				dataKey: READ_STATUS_COLUMN_ID,
@@ -307,6 +299,27 @@ export default class ZoteroReadingList {
 					return cell;
 				},
 			});
+	}
+
+	/**
+	 * Format name of status to localise text and include icon if enabled.
+	 * @param {string} statusName - The name of the status.
+	 * @returns {String} values - Name of the status, possibly prefixed with the corresponding icon.
+	 */
+	formatStatusName(statusName: string): string {
+		if (getPref(SHOW_ICONS_PREF)) {
+			const statusIndex = this.statusNames.indexOf(statusName);
+			// const localisedStatus = getString(
+			// 	`status-${statusName.toLowerCase().replace(" ", "_")}`,
+			// );
+			// if (statusIndex > -1) {
+			// 	return `${this.statusIcons[statusIndex]} ${localisedStatus}`;
+			// }
+			if (statusIndex > -1) {
+				return `${this.statusIcons[statusIndex]} ${statusName}`;
+			}
+		}
+		return statusName;
 	}
 
 	removeReadStatusColumn() {
@@ -345,12 +358,10 @@ export default class ZoteroReadingList {
 						void clearSelectedItemsReadStatus("item"),
 				} as MenuitemOptions,
 			].concat(
-				STATUS_NAMES.map((status_name: string) => {
+				this.statusNames.map((status_name: string) => {
 					return {
 						tag: "menuitem",
-						label: getString(
-							`status-${status_name.toLowerCase().replace(" ", "_")}`,
-						),
+						label: status_name,
 						commandListener: (event) =>
 							setSelectedItemsReadStatus("item", status_name),
 					};
@@ -407,15 +418,16 @@ export default class ZoteroReadingList {
 	keyboardEventHandler = (keyboardEvent: KeyboardEvent) => {
 		// Check modifiers - want Alt+{1,2,3,4,5} to label the currently selected items
 		// Or Alt+0 to clear the current read status
+		const possibleKeyCombinations = [...Array(this.statusNames.length).keys()].map((num) => (num+1).toString())
 		if (
 			!keyboardEvent.ctrlKey &&
 			!keyboardEvent.shiftKey &&
 			keyboardEvent.altKey
 		) {
-			if (["1", "2", "3", "4", "5"].includes(keyboardEvent.key)) {
+			if (possibleKeyCombinations.includes(keyboardEvent.key)) {
 				const selectedStatus =
-					STATUS_NAMES[
-						["1", "2", "3", "4", "5"].indexOf(keyboardEvent.key)
+					this.statusNames[
+						possibleKeyCombinations.indexOf(keyboardEvent.key)
 					];
 				void setSelectedItemsReadStatus("item", selectedStatus);
 			} else if (keyboardEvent.key == "0") {

--- a/src/utils/prefs.ts
+++ b/src/utils/prefs.ts
@@ -10,6 +10,14 @@ export function getPref(key: string) {
 }
 
 /**
+ * Get global name of preference.
+ * @param key
+ */
+export function getPrefGlobalName(key: string) {
+	return `${config.prefsPrefix}.${key}`;
+}
+
+/**
  * Set preference value.
  * Wrapper of `Zotero.Prefs.set`.
  * @param key
@@ -18,6 +26,19 @@ export function getPref(key: string) {
 export function setPref(key: string, value: string | number | boolean) {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return Zotero.Prefs.set(`${config.prefsPrefix}.${key}`, value, true);
+}
+
+/**
+ * Set preference to a default value if it isn't already set.
+ * @param key
+ * @param defaultValue
+ */
+export function initialiseDefaultPref(
+	key: string, defaultValue: string | number | boolean,
+) {
+	if (getPref(key) === undefined) {
+		setPref(key, defaultValue);
+	}
 }
 
 /**


### PR DESCRIPTION
They can be set in the settings menu, along with status icons.

The first 9 will have shortcuts enabled (Alt+1...9), with Alt+0 reserved for clearing the item's read status.