### PR TITLE
Allow more customised formatting of read status column

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -15,11 +15,6 @@
 			<html:h2 data-l10n-id="pref-title"></html:h2>
 		</label>
 		<checkbox
-			id="zotero-prefpane-__addonRef__-show-icons"
-			preference="extensions.zotero.__addonRef__.show-icons"
-			data-l10n-id="pref-show-icons"
-		/>
-		<checkbox
 			id="zotero-prefpane-__addonRef__-enable-keyboard-shortcuts"
 			preference="extensions.zotero.__addonRef__.enable-keyboard-shortcuts"
 			data-l10n-id="pref-enable-keyboard-shortcuts"
@@ -28,6 +23,35 @@
 			id="zotero-prefpane-__addonRef__-label-new-items"
 			preference="extensions.zotero.__addonRef__.label-new-items"
 			data-l10n-id="pref-label-new-items"
+		/>
+	</groupbox>
+	<!-- Read Status column format -->
+	<groupbox>
+		<label>
+			<html:h2
+				data-l10n-id="pref-readstatuscolumn-format-title"
+			></html:h2>
+		</label>
+		<radiogroup
+			preference="extensions.zotero.__addonRef__.read-status-format"
+		>
+			<radio
+				value="0"
+				data-l10n-id="pref-readstatuscolumn-format-showboth"
+			/>
+			<radio
+				value="1"
+				data-l10n-id="pref-readstatuscolumn-format-showtext"
+			/>
+			<radio
+				value="2"
+				data-l10n-id="pref-readstatuscolumn-format-showicon"
+			/>
+		</radiogroup>
+		<checkbox
+			id="zotero-prefpane-__addonRef__-readstatuscolumn-header-showicon"
+			preference="extensions.zotero.__addonRef__.readstatuscolumn-format-header-showicon"
+			data-l10n-id="pref-readstatuscolumn-header-showicon"
 		/>
 	</groupbox>
 	<!-- Status names -->

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -1,4 +1,5 @@
 menupopup-label = Read Status
+read-status = Read Status
 status-none = None
 status-new = New
 status-to_read = To Read

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -1,6 +1,4 @@
 pref-title = Zotero Reading List Settings
-pref-show-icons =
-    .label = Show icons along with an item's read status
 pref-enable-keyboard-shortcuts =
     .label = Enable keyboard shortcuts (Alt+0,1,2,3,4,5, ...). This disables Zotero's column sorting shortcuts!
 pref-label-new-items =
@@ -8,6 +6,17 @@ pref-label-new-items =
 pref-label-items-when-opening-file = 
     .label = Automatically change the read status of items when opening an attached file
 pref-help = { $name } Build { $version } { $time }
+
+pref-readstatuscolumn-format-title = Read Status Column Format
+pref-readstatuscolumn-format-showboth =
+    .label = Show icon and text (eg. ⭐ New)
+pref-readstatuscolumn-format-showtext = 
+    .label = Show only text (eg. New)
+pref-readstatuscolumn-format-showicon = 
+    .label = Show only icon (eg. ⭐)
+pref-readstatuscolumn-header-showicon = 
+    .label = Show extension icon instead of "Read Status" as column header
+
 pref-statuslabeltable-title = Custom Reading Statuses
 pref-statuslabeltable-header-number = Number
 pref-statuslabeltable-header-statusicon = Status Icon

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -16,7 +16,6 @@ import {
 } from "../utils/extraField";
 
 const READ_STATUS_COLUMN_ID = "readstatus";
-const READ_STATUS_COLUMN_NAME = "Read Status";
 const READ_STATUS_EXTRA_FIELD = "Read_Status";
 const READ_DATE_EXTRA_FIELD = "Read_Status_Date";
 
@@ -264,7 +263,7 @@ export default class ZoteroReadingList {
 		this.itemTreeReadStatusColumnId =
 			await Zotero.ItemTreeManager.registerColumns({
 				dataKey: READ_STATUS_COLUMN_ID,
-				label: READ_STATUS_COLUMN_NAME,
+				label: getString("read-status"),
 				// If we just want to show the icon, overwrite the label with htmlLabel (#40)
 				htmlLabel: getPref(READ_STATUS_FORMAT_HEADER_SHOW_ICON)
 					? `<span class="icon icon-css icon-16" style="background: url(chrome://${config.addonRef}/content/icons/favicon.png) content-box no-repeat center/contain;" />`


### PR DESCRIPTION
Fixes #40

It is now possible to format the content of the read status column as either:
* icon and text
* only text
* only icon

And it is now possible to show the extension icon instead of "Read Status" as the column header.