### PR TITLE
Don't allow duplicate or invalid custom read statuses

### DIFF
--- a/addon/chrome/content/preferences.css
+++ b/addon/chrome/content/preferences.css
@@ -16,3 +16,7 @@ table th {
 	text-align: left;
 	margin-left: 6px;
 }
+
+input:invalid {
+	color: rgb(255, 20, 20);
+}

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -7,3 +7,6 @@ status-in_progress = In Progress
 status-read = Read
 status-not_reading = Not Reading
 prefs-title = Reading List
+
+duplicate-status-names-title = Duplicate Custom Reading Statuses
+duplicate-status-names-description = One or more custom reading status names are duplicated. This isn't supported. Please ensure all your custom reading status names are unique.

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -9,4 +9,4 @@ status-not_reading = Not Reading
 prefs-title = Reading List
 
 duplicate-status-names-title = Duplicate Custom Reading Statuses
-duplicate-status-names-description = One or more custom reading status names are duplicated. This isn't supported. Please ensure all your custom reading status names are unique.
+duplicate-status-names-description = Two or more custom reading status names are the same. This isn't supported. Please ensure all of your custom reading status names are unique.

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -10,3 +10,5 @@ prefs-title = Reading List
 
 duplicate-status-names-title = Duplicate Custom Reading Statuses
 duplicate-status-names-description = Two or more custom reading status names are the same. This isn't supported. Please ensure all of your custom reading status names are unique.
+invalid-status-names-title = Custom Reading Statuses Contains Invalid Characters
+invalid-status-names-description = Custom reading statuses and icons cannot contain the characters ; or |. Please remove these characters.

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -89,6 +89,8 @@ function getSelectedItems() {
 	return ZoteroPane.getSelectedItems().filter((item) => item.isRegularItem());
 }
 
+export const FORBIDDEN_PREF_STRING_CHARACTERS = new Set(";|");
+
 export function prefStringToList(
 	prefString: string | number | boolean | undefined,
 ) {

--- a/src/prefs-menu.ts
+++ b/src/prefs-menu.ts
@@ -10,6 +10,7 @@ import {
 	listToPrefString,
 } from "./modules/overlay";
 import { getPref, setPref } from "./utils/prefs";
+import { getString } from "./utils/locale";
 
 const STATUS_NAMES_TABLE_BODY = "statusnames-table-body";
 const OPEN_ITEM_TABLE_BODY = "openitem-table-body";
@@ -111,6 +112,15 @@ function saveTableStatusNames(window: Window) {
 		icons.push((row.children[0].firstChild as HTMLInputElement).value);
 		names.push((row.children[1].firstChild as HTMLInputElement).value);
 	}
+	if (new Set(names).size != names.length) {
+		Services.prompt.alert(
+			window as mozIDOMWindowProxy,
+			getString("duplicate-status-names-title"),
+			getString("duplicate-status-names-description"),
+		);
+		return;
+	}
+
 	setPref(STATUS_NAME_AND_ICON_LIST_PREF, listToPrefString(names, icons));
 	// if we change the statuses, need to reset the status lists here
 	clearTableOpenItem(window);


### PR DESCRIPTION
Fixes #41

Don't allow duplicate read status names, as they need to be unique to identify the actual read status.

Don't allow invalid characters (`;` or `|`) in read statuses or icons because they are used for delimiting the different read statuses in the preferences string.