### PR TITLE
Update keyboard shortcut logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zotero Reading List
 
-![downloads](https://img.shields.io/github/downloads/dominic-dallosto/zotero-reading-list/latest/zotero-reading-list.xpi?style=flat-square&label=Downloads%20(latest%20version))
+![downloads](<https://img.shields.io/github/downloads/dominic-dallosto/zotero-reading-list/latest/zotero-reading-list.xpi?style=flat-square&label=Downloads%20(latest%20version)>)
 
 An extension for Zotero that allows setting the read status of items.
 

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -501,40 +501,20 @@ export default class ZoteroReadingList {
 		// Or Alt+0 to clear the current read status
 		const possibleKeyCombinations = [
 			...Array(Math.min(8, this.statusNames.length)).keys(),
-		].map((num) => (num + 1).toString());
-		// On Mac, Alt is equivalent to Opt but this changes the key of the event
-		// eg. 1 -> ¡
-		// see #9
-		const possibleKeyCombinationsMac = [
-			"¡",
-			"™",
-			"£",
-			"¢",
-			"∞",
-			"§",
-			"¶",
-			"•",
-			"ª",
-		].slice(0, possibleKeyCombinations.length);
-		const clearStatusKeyCombinations = ["0", "º"];
+		].map((num) => `Digit${(num + 1).toString()}`);
+		const clearStatusKeyCombinations = ["Backquote"];
 		if (
 			!keyboardEvent.ctrlKey &&
 			!keyboardEvent.shiftKey &&
 			keyboardEvent.altKey
 		) {
-			if (possibleKeyCombinations.includes(keyboardEvent.key)) {
+			if (possibleKeyCombinations.includes(keyboardEvent.code)) {
 				const selectedStatus =
 					this.statusNames[
-						possibleKeyCombinations.indexOf(keyboardEvent.key)
+						possibleKeyCombinations.indexOf(keyboardEvent.code)
 					];
 				void setSelectedItemsReadStatus(selectedStatus);
-			} else if (possibleKeyCombinationsMac.includes(keyboardEvent.key)) {
-				const selectedStatus =
-					this.statusNames[
-						possibleKeyCombinationsMac.indexOf(keyboardEvent.key)
-					];
-				void setSelectedItemsReadStatus(selectedStatus);
-			} else if (clearStatusKeyCombinations.includes(keyboardEvent.key)) {
+			} else if (clearStatusKeyCombinations.includes(keyboardEvent.code)) {
 				void clearSelectedItemsReadStatus();
 			}
 		}

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -499,22 +499,28 @@ export default class ZoteroReadingList {
 	keyboardEventHandler = (keyboardEvent: KeyboardEvent) => {
 		// Check modifiers - want Alt+{1,2,3,4,5} to label the currently selected items
 		// Or Alt+0 to clear the current read status
-		const possibleKeyCombinations = [
-			...Array(Math.min(8, this.statusNames.length)).keys(),
-		].map((num) => `Digit${(num + 1).toString()}`);
-		const clearStatusKeyCombinations = ["Backquote"];
+		// Need to use keyboard event `code` instead of `key` to support different keyboard
+		// layouts, as well as fix problems with Mac #9 #53
+		const possibleKeyCombinations: Map<string, number> = new Map();
+		for (let num = 0; num < this.statusNames.length; num++) {
+			possibleKeyCombinations.set(`Digit${num + 1}`, num);
+			possibleKeyCombinations.set(`Numpad${num + 1}`, num);
+		}
+		const clearStatusKeyCombinations = ["Digit0", "Numpad0"];
 		if (
 			!keyboardEvent.ctrlKey &&
 			!keyboardEvent.shiftKey &&
 			keyboardEvent.altKey
 		) {
-			if (possibleKeyCombinations.includes(keyboardEvent.code)) {
+			if (possibleKeyCombinations.has(keyboardEvent.code)) {
 				const selectedStatus =
 					this.statusNames[
-						possibleKeyCombinations.indexOf(keyboardEvent.code)
+						possibleKeyCombinations.get(keyboardEvent.code)!
 					];
 				void setSelectedItemsReadStatus(selectedStatus);
-			} else if (clearStatusKeyCombinations.includes(keyboardEvent.code)) {
+			} else if (
+				clearStatusKeyCombinations.includes(keyboardEvent.code)
+			) {
 				void clearSelectedItemsReadStatus();
 			}
 		}


### PR DESCRIPTION
Fixes #9 (without relying on layout and language-dependent hardcoded keys). Instead of `key`, the code now uses `code`, which corresponds to a layout-independent and modifier-independent mapping of the keys. Tested on my Mac and it now finally works. The previous fix most likely only worked for a specific keyboard layout.

See [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) for reference.

Please test on other platforms, but should work everywhere.