### PR TITLE
Update `zotero-plugin-toolkit` to v4 to fix plugin conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zotero-reading-list",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zotero-reading-list",
-			"version": "1.5.1",
+			"version": "1.5.2",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"zotero-plugin-toolkit": "^4.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.5.1",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"zotero-plugin-toolkit": "^2.3.37"
+				"zotero-plugin-toolkit": "^4.0.6"
 			},
 			"devDependencies": {
 				"@types/node": "^20.10.4",
@@ -21,11 +21,11 @@
 				"eslint": "^8.55.0",
 				"eslint-config-prettier": "^9.1.0",
 				"prettier": "^3.1.1",
-				"release-it": "^17.0.1",
+				"release-it": "^17.7.0",
 				"replace-in-file": "^7.0.2",
 				"typescript": "^5.3.3",
-				"zotero-plugin-scaffold": "^0.0.33",
-				"zotero-types": "^2.1.0"
+				"zotero-plugin-scaffold": "^0.1.6",
+				"zotero-types": "^2.2.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -35,6 +35,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "11.6.1",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.1.tgz",
+			"integrity": "sha512-DxjgKBCoyReu4p5HMvpmgSOfRhhBcuf5V5soDDRgOTZMwsA4KSFzol1abFZgiCTE11L2kKGca5Md9GwDdXVBwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.15",
+				"js-yaml": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/philsturgeon"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -216,15 +234,26 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-			"integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@commander-js/extra-typings": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-12.1.0.tgz",
+			"integrity": "sha512-wf/lwQvWAA0goIghcb91dQYpkLBcyhOhQNqG/VgWhnKzgt+UOMvra7EX/2fv70arm5RW+PUHoQHHDa6/p77Eqg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"commander": "~12.1.0"
 			}
 		},
 		"node_modules/@conventional-changelog/git-client": {
@@ -257,6 +286,7 @@
 			"resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.2.6.tgz",
 			"integrity": "sha512-8lO1hSeTgtxcOHhp4tTWq/JaOysp5KNbbyFoxNEBnwkCDZu/Bji3ZfOaG++Riv9jN6c9bgdLBOZqJTC5VJPRKQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@devicefarmer/adbkit-logcat": "^2.1.2",
 				"@devicefarmer/adbkit-monkey": "~1.2.1",
@@ -278,6 +308,7 @@
 			"resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-logcat/-/adbkit-logcat-2.1.3.tgz",
 			"integrity": "sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -287,6 +318,7 @@
 			"resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-monkey/-/adbkit-monkey-1.2.1.tgz",
 			"integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.10.4"
 			}
@@ -296,6 +328,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
 			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
@@ -311,13 +344,14 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
-			"integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+			"integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"aix"
@@ -327,13 +361,14 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
-			"integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+			"integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -343,13 +378,14 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
-			"integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+			"integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -359,13 +395,14 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
-			"integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+			"integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -375,13 +412,14 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
-			"integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+			"integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -391,13 +429,14 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
-			"integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+			"integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -407,13 +446,14 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
-			"integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+			"integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -423,13 +463,14 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
-			"integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+			"integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -439,13 +480,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
-			"integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+			"integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -455,13 +497,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
-			"integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+			"integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -471,13 +514,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
-			"integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+			"integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -487,13 +531,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
-			"integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+			"integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -503,13 +548,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
-			"integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+			"integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
 			"cpu": [
 				"mips64el"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -519,13 +565,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
-			"integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+			"integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -535,13 +582,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
-			"integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+			"integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -551,13 +599,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
-			"integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+			"integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -567,13 +616,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
-			"integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+			"integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -583,13 +633,14 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
-			"integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+			"integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -599,13 +650,14 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
-			"integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+			"integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -615,13 +667,14 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
-			"integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+			"integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -631,13 +684,14 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
-			"integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+			"integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
@@ -647,13 +701,14 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
-			"integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+			"integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -663,13 +718,14 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
-			"integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+			"integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -764,10 +820,11 @@
 			"dev": true
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -777,18 +834,100 @@
 			"resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
 			"integrity": "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14.0.0",
 				"npm": ">=7.0.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.14",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+		"node_modules/@gitee/typescript-sdk-v5": {
+			"version": "5.4.85",
+			"resolved": "https://registry.npmjs.org/@gitee/typescript-sdk-v5/-/typescript-sdk-v5-5.4.85.tgz",
+			"integrity": "sha512-z7+In2BQAaLlykhEUVv87RvFAhBfRr27dqg4TtzyXV50AKzqzI6+SQrjDB2UEdWZ6N95GF10RgaV2z5dtRIfeg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.2",
+				"@hey-api/openapi-ts": "^0.43.2",
+				"axios": "^1.6.8",
+				"typescript": "^5.4.5"
+			}
+		},
+		"node_modules/@hey-api/openapi-ts": {
+			"version": "0.43.2",
+			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.43.2.tgz",
+			"integrity": "sha512-o1/w+9tk1Ty/LJBy/VrHvDzA8YkCSRi1rr567aABlLwa9pbl2WP5fsUQbXGOgZ1HsLieVXo6qwcNMNqC6v2oxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "11.6.1",
+				"c12": "1.10.0",
+				"camelcase": "8.0.0",
+				"commander": "12.0.0",
+				"handlebars": "4.7.8"
+			},
+			"bin": {
+				"openapi-ts": "bin/index.cjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"typescript": "^5.x"
+			}
+		},
+		"node_modules/@hey-api/openapi-ts/node_modules/c12": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-1.10.0.tgz",
+			"integrity": "sha512-0SsG7UDhoRWcuSvKWHaXmu5uNjDCDN3nkQLRL4Q42IlFy+ze58FcCoI3uPwINXinkz7ZinbhEgyzYFw9u9ZV8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^3.6.0",
+				"confbox": "^0.1.3",
+				"defu": "^6.1.4",
+				"dotenv": "^16.4.5",
+				"giget": "^1.2.1",
+				"jiti": "^1.21.0",
+				"mlly": "^1.6.1",
+				"ohash": "^1.1.3",
+				"pathe": "^1.1.2",
+				"perfect-debounce": "^1.0.0",
+				"pkg-types": "^1.0.3",
+				"rc9": "^2.1.1"
+			}
+		},
+		"node_modules/@hey-api/openapi-ts/node_modules/camelcase": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@hey-api/openapi-ts/node_modules/commander": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+			"integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
@@ -810,10 +949,12 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
-			"dev": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hutson/parse-repository-url": {
 			"version": "5.0.0",
@@ -831,14 +972,15 @@
 			"dev": true
 		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.2.tgz",
-			"integrity": "sha512-iZRNbTlSB9xXt/+jdMFViBdxw1ILWu3365rzfM5OLwAyOScbDFFGSH7LEUwoq1uOIo48ymOEwYSqP5y8hQMlmA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
+			"integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
+				"@inquirer/core": "^9.1.0",
 				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/type": "^1.5.3",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -847,31 +989,32 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "3.1.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.17.tgz",
-			"integrity": "sha512-qCpt/AABzPynz8tr69VDvhcjwmzAryipWXtW8Vi6m651da4H/d0Bdn55LkxXD7Rp2gfgxvxzTdb66AhIA8gzBA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
+			"integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1"
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.5.tgz",
-			"integrity": "sha512-QWG41I7vn62O9stYKg/juKXt1PEbr/4ZZCPb4KgXDQGwgA9M5NBTQ7FnOvT1ridbxkm/wTxLCNraUs7y47pIRQ==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+			"integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/figures": "^1.0.6",
+				"@inquirer/type": "^2.0.0",
 				"@types/mute-stream": "^0.0.4",
-				"@types/node": "^20.14.11",
+				"@types/node": "^22.5.5",
 				"@types/wrap-ansi": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
-				"cli-spinners": "^2.9.2",
 				"cli-width": "^4.1.0",
 				"mute-stream": "^1.0.0",
 				"signal-exit": "^4.1.0",
@@ -883,17 +1026,42 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@inquirer/core/node_modules/@inquirer/type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+			"integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mute-stream": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/@types/node": {
+			"version": "22.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+			"integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.19.2"
+			}
+		},
 		"node_modules/@inquirer/core/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@inquirer/core/node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=14"
 			},
@@ -906,6 +1074,7 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -915,11 +1084,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@inquirer/core/node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
 			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -930,13 +1107,14 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.17.tgz",
-			"integrity": "sha512-hwx3VpFQzOY2hFWnY+XPsUGCIUVQ5kYxH6+CExv/RbMiAoN3zXtzj8DyrWBOHami0vBrrnPS8CTq3uQWc7N2BA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
+			"integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3",
 				"external-editor": "^3.1.0"
 			},
 			"engines": {
@@ -944,13 +1122,14 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.17.tgz",
-			"integrity": "sha512-s4V/dC+GeE5s97xoTtZSmC440uNKePKqZgzqEf0XM63ciilnXAtKGvoAWOePFdlK+oGTz0d8bhbPKwpKGvRYfg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
+			"integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -958,48 +1137,52 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
-			"integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
+			"integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.4.tgz",
-			"integrity": "sha512-wvYnDITPQn+ltktj/O9kQjPxOvpmwcpxLWh8brAyD+jlEbihxtrx9cZdZcxqaCVQj3caw4eZa2Uq5xELo4yXkA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
+			"integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1"
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.5.tgz",
-			"integrity": "sha512-+H6TJPU2AJEcoF6nVTWssxS7gnhxWvf6CkILAdfq/yGm/htBKNDrvYLYaJvi1Be/aXQoKID9FaP94bUCjOvJNQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
+			"integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1"
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.17.tgz",
-			"integrity": "sha512-/u6DM/fDHXoBWyA+9aRhghkeo5smE7wO9k4E2UoJbgiRCkt3JjBEuBqLOJNrz8E16M0ez4UM1vd5cXrmICHW+A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
+			"integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3",
 				"ansi-escapes": "^4.3.2"
 			},
 			"engines": {
@@ -1007,33 +1190,52 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.2.0.tgz",
-			"integrity": "sha512-7jBWrlkvprEHEFw29zG/piw/M76c5/zYQWfi8ybHeyzcTuXkh1NjDQxLg2PiruvsIt36z1zvKM5yn7vbF0Yr/A==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
+			"integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^2.4.0",
-				"@inquirer/confirm": "^3.1.15",
-				"@inquirer/editor": "^2.1.15",
-				"@inquirer/expand": "^2.1.15",
-				"@inquirer/input": "^2.2.2",
-				"@inquirer/number": "^1.0.3",
-				"@inquirer/password": "^2.1.15",
-				"@inquirer/rawlist": "^2.1.15",
-				"@inquirer/select": "^2.4.0"
+				"@inquirer/checkbox": "^2.5.0",
+				"@inquirer/confirm": "^3.2.0",
+				"@inquirer/editor": "^2.2.0",
+				"@inquirer/expand": "^2.3.0",
+				"@inquirer/input": "^2.3.0",
+				"@inquirer/number": "^1.1.0",
+				"@inquirer/password": "^2.2.0",
+				"@inquirer/rawlist": "^2.3.0",
+				"@inquirer/search": "^1.1.0",
+				"@inquirer/select": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.17.tgz",
-			"integrity": "sha512-RFrw34xU5aVlMA3ZJCaeKGxYjhu3j4i46O2GMmaRRGeLObCRM1yOKQOsRclSTzjd4A7+M5QleR2iuW/68J9Kwg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
+			"integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/type": "^1.5.3",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.1.0",
+				"@inquirer/figures": "^1.0.5",
+				"@inquirer/type": "^1.5.3",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -1041,14 +1243,15 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.2.tgz",
-			"integrity": "sha512-r78JlgShqRxyAtBDeBHSDtfrOhSQwm2ecWGGaxe7kD9JwgL3UN563G1ncVRYdsWD7/tigflcskfipVeoDLhLJg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
+			"integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^9.0.5",
+				"@inquirer/core": "^9.1.0",
 				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.1",
+				"@inquirer/type": "^1.5.3",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -1057,10 +1260,11 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.1.tgz",
-			"integrity": "sha512-m3YgGQlKNS0BM+8AFiJkCsTqHEFCWn6s/Rqye3mYwvqY6LdfUv12eSwbsgNzrYyrLXiy7IrrjDLPysaSBwEfhw==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+			"integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mute-stream": "^1.0.0"
 			},
@@ -1073,6 +1277,7 @@
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
 			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
 				"string-width-cjs": "npm:string-width@^4.2.0",
@@ -1086,10 +1291,11 @@
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -1102,6 +1308,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
 			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
 			},
@@ -1117,6 +1324,7 @@
 			"resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
 			"integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"call-me-maybe": "^1.0.1",
 				"cross-spawn": "^7.0.3",
@@ -1127,17 +1335,12 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@ljharb/through": {
-			"version": "2.3.12",
-			"resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.12.tgz",
-			"integrity": "sha512-ajo/heTlG3QgC8EGP6APIejksVAYt4ayz4tqoP3MolFELzcH1x1fzwEYRJTPO0IELutZ5HQ0c26/GqAYy79u3g==",
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
 			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@mapbox/node-pre-gyp": {
 			"version": "1.0.11",
@@ -1205,10 +1408,11 @@
 			}
 		},
 		"node_modules/@mdn/browser-compat-data": {
-			"version": "5.5.34",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.34.tgz",
-			"integrity": "sha512-e8k7+8r3jiJuP7FMH6AL1OnmfQqLyABhTM+NmRDvFeAbMgtFcNQLHpmT7uza5cBnxI01+CAU3aSsIgcKGRdEBQ==",
-			"dev": true
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.6.0.tgz",
+			"integrity": "sha512-xArvLyzuk0r2m6hFVjTMYoLvhWwys3h7W8pO15tjSAea+U39cErWDNfoUs4g2C08HVg6bDHyDMBc0LC6FKRpVw==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1317,12 +1521,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest": {
 			"version": "11.3.3",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
@@ -1363,15 +1561,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/app/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@octokit/app/node_modules/before-after-hook": {
@@ -1418,12 +1607,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/auth-app/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1450,21 +1633,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
-		"node_modules/@octokit/auth-app/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true
 		},
 		"node_modules/@octokit/auth-app/node_modules/universal-user-agent": {
 			"version": "7.0.2",
@@ -1501,12 +1669,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1532,15 +1694,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/universal-user-agent": {
@@ -1577,12 +1730,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1608,15 +1755,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/universal-user-agent": {
@@ -1654,12 +1792,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1687,15 +1819,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/universal-user-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
@@ -1707,6 +1830,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
 			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
 			}
@@ -1724,12 +1848,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/request-error": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
@@ -1742,26 +1860,18 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/@octokit/core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-			"integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+			"integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
-				"@octokit/graphql": "^7.0.0",
-				"@octokit/request": "^8.0.2",
-				"@octokit/request-error": "^5.0.0",
-				"@octokit/types": "^12.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -1770,12 +1880,13 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-			"integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+			"integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.0.0",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -1783,13 +1894,14 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-			"integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+			"integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^8.0.1",
-				"@octokit/types": "^12.0.0",
+				"@octokit/request": "^8.3.0",
+				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -1869,12 +1981,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/oauth-app/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/oauth-app/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1900,15 +2006,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/oauth-app/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@octokit/oauth-app/node_modules/before-after-hook": {
@@ -1960,12 +2057,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/oauth-methods/node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
@@ -1993,15 +2084,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/@octokit/oauth-methods/node_modules/universal-user-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
@@ -2009,10 +2091,11 @@
 			"dev": true
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-			"dev": true
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@octokit/openapi-webhooks-types": {
 			"version": "8.3.0",
@@ -2021,56 +2104,60 @@
 			"dev": true
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.0.tgz",
-			"integrity": "sha512-NKi0bJEZqOSbBLMv9kdAcuocpe05Q2xAXNLTGi0HN2GSMFJHNZuSoPNa0tcQFTOFCKe+ZaYBZ3lpXh1yxgUDCA==",
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
+			"integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.6.0"
+				"@octokit/types": "^13.5.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=5"
+				"@octokit/core": "5"
 			}
 		},
 		"node_modules/@octokit/plugin-request-log": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-			"integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=5"
+				"@octokit/core": "5"
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.0.tgz",
-			"integrity": "sha512-INw5rGXWlbv/p/VvQL63dhlXr38qYTHkQ5bANi9xofrF9OraqmjHsIGyenmjmul1JVRHpUlw5heFOj1UZLEolA==",
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
+			"integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.6.0"
+				"@octokit/types": "^13.5.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=5"
+				"@octokit/core": "^5"
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-			"integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+			"integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^9.0.0",
-				"@octokit/request-error": "^5.0.0",
-				"@octokit/types": "^12.0.0",
+				"@octokit/endpoint": "^9.0.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -2078,12 +2165,13 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-			"integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+			"integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.0.0",
+				"@octokit/types": "^13.1.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			},
@@ -2092,27 +2180,29 @@
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "20.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
-			"integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
+			"version": "20.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+			"integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/core": "^5.0.0",
-				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/core": "^5.0.2",
+				"@octokit/plugin-paginate-rest": "11.3.1",
 				"@octokit/plugin-request-log": "^4.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+				"@octokit/plugin-rest-endpoint-methods": "13.2.2"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"version": "13.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+			"integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
+				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@octokit/webhooks": {
@@ -2138,12 +2228,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/webhooks/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
-		},
 		"node_modules/@octokit/webhooks/node_modules/@octokit/request-error": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
@@ -2156,20 +2240,12 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/webhooks/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
 			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=14"
@@ -2180,6 +2256,7 @@
 			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
 			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.22.0"
 			}
@@ -2189,6 +2266,7 @@
 			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
 			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "4.2.10"
 			},
@@ -2197,10 +2275,11 @@
 			}
 		},
 		"node_modules/@pnpm/npm-conf": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
-			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
+			"integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@pnpm/config.env-replace": "^1.1.0",
 				"@pnpm/network.ca-file": "^1.0.1",
@@ -2210,40 +2289,17 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@sindresorhus/is": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
 		"node_modules/@sindresorhus/merge-streams": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
 			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@szmarczak/http-timer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-			"integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-			"dev": true,
-			"dependencies": {
-				"defer-to-connect": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=14.16"
 			}
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
@@ -2262,12 +2318,6 @@
 			"version": "3.5.42",
 			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
 			"integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A=="
-		},
-		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-			"dev": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -2288,13 +2338,15 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/mute-stream": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
 			"integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -2338,13 +2390,15 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
 			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/yauzl": {
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
 			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -2580,6 +2634,7 @@
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
 			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"event-target-shim": "^5.0.0"
 			},
@@ -2588,10 +2643,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2615,39 +2671,36 @@
 			"dev": true
 		},
 		"node_modules/addons-linter": {
-			"version": "6.31.1",
-			"resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-6.31.1.tgz",
-			"integrity": "sha512-R9FCyVzqU/h5A2aB1t+jD8t4QKLuLxYqc1FjmjJ0nZrn1qNCna1jFOajt5R1T8pwt0H4WXgT+uwWSD2BdkBzqQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-7.1.0.tgz",
+			"integrity": "sha512-UmkUB3dZSpf8bqhlulGDbpoxBwcfOk8JvaJTRvJ+AAXKHvTjqeNlFC+GRMqa0EjJJh/0yqpBaJzyaUIx+fjl+A==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
 				"@fluent/syntax": "0.19.0",
-				"@mdn/browser-compat-data": "5.5.34",
+				"@mdn/browser-compat-data": "5.6.0",
 				"addons-moz-compare": "1.3.0",
 				"addons-scanner-utils": "9.11.0",
-				"ajv": "8.16.0",
+				"ajv": "8.17.1",
 				"chalk": "4.1.2",
 				"cheerio": "1.0.0-rc.12",
 				"columnify": "1.6.0",
 				"common-tags": "1.8.2",
 				"deepmerge": "4.3.1",
-				"eslint": "8.57.0",
+				"eslint": "8.57.1",
 				"eslint-plugin-no-unsanitized": "4.0.2",
 				"eslint-visitor-keys": "4.0.0",
-				"espree": "10.0.1",
+				"espree": "10.1.0",
 				"esprima": "4.0.1",
 				"fast-json-patch": "3.1.1",
-				"glob": "10.4.2",
 				"image-size": "1.1.1",
-				"is-mergeable-object": "1.1.1",
 				"jed": "1.1.1",
 				"json-merge-patch": "1.0.2",
 				"os-locale": "5.0.0",
 				"pino": "8.20.0",
 				"relaxed-json": "1.0.3",
-				"semver": "7.6.2",
-				"sha.js": "2.4.11",
+				"semver": "7.6.3",
 				"source-map-support": "0.5.21",
-				"tosource": "1.0.0",
 				"upath": "2.0.1",
 				"yargs": "17.7.2",
 				"yauzl": "2.10.0"
@@ -2656,14 +2709,123 @@
 				"addons-linter": "bin/addons-linter"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/addons-linter/node_modules/addons-scanner-utils": {
+		"node_modules/addons-linter/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/addons-linter/node_modules/espree": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+			"integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.12.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/addons-linter/node_modules/pino": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-8.20.0.tgz",
+			"integrity": "sha512-uhIfMj5TVp+WynVASaVEJFTncTUe4dHBq6CWplu/vBgvGHhvBvQfxz+vcOrnnBQdORH3izaGEurLfNlq3YxdFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^1.1.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^3.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.7.0",
+				"thread-stream": "^2.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/addons-linter/node_modules/pino-std-serializers": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/addons-linter/node_modules/process-warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+			"integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/addons-linter/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/addons-linter/node_modules/sonic-boom": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+			"integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/addons-linter/node_modules/thread-stream": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+			"integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
+		"node_modules/addons-moz-compare": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/addons-moz-compare/-/addons-moz-compare-1.3.0.tgz",
+			"integrity": "sha512-/rXpQeaY0nOKhNx00pmZXdk5Mu+KhVlL3/pSBuAYwrxRrNiTvI/9xfQI8Lmm7DMMl+PDhtfAHY/0ibTpdeoQQQ==",
+			"dev": true,
+			"license": "MPL-2.0"
+		},
+		"node_modules/addons-scanner-utils": {
 			"version": "9.11.0",
 			"resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-9.11.0.tgz",
 			"integrity": "sha512-X95V8ymnue9EHmOLz3zJTGHvHDFlWKiavlH+kJKOlv2sJDWFvD3TWeJMHJgxS9GKOqT/545mOXvX3vuuGGum+g==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
 				"@types/yauzl": "2.10.3",
 				"common-tags": "1.8.2",
@@ -2693,136 +2855,12 @@
 				}
 			}
 		},
-		"node_modules/addons-linter/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/addons-linter/node_modules/eslint-visitor-keys": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/addons-linter/node_modules/espree": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.11.3",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/addons-linter/node_modules/glob": {
-			"version": "10.4.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-			"integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
-			"dev": true,
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/addons-linter/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/addons-linter/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/addons-linter/node_modules/node-fetch": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-			"integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/addons-linter/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/addons-moz-compare": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/addons-moz-compare/-/addons-moz-compare-1.3.0.tgz",
-			"integrity": "sha512-/rXpQeaY0nOKhNx00pmZXdk5Mu+KhVlL3/pSBuAYwrxRrNiTvI/9xfQI8Lmm7DMMl+PDhtfAHY/0ibTpdeoQQQ==",
-			"dev": true
-		},
 		"node_modules/adm-zip": {
-			"version": "0.5.14",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-			"integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
 			}
@@ -2840,15 +2878,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -2935,12 +2974,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/any-promise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-			"dev": true
-		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2980,27 +3013,12 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/array-buffer-byte-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.5",
-				"is-array-buffer": "^3.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array-differ": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
 			"integrity": "sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
@@ -3023,47 +3041,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array.prototype.map": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.6.tgz",
-			"integrity": "sha512-nK1psgF2cXqP3wSyCSq0Hc7zwNq3sfljQqaG27r/7a7ooNUnn5nGq6yYWyks9jMO5EoFQ0ax80hSg6oXSRNXaw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
-			"dev": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.1",
-				"call-bind": "^1.0.5",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.22.3",
-				"es-errors": "^1.2.1",
-				"get-intrinsic": "^1.2.3",
-				"is-array-buffer": "^3.0.4",
-				"is-shared-array-buffer": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -3077,10 +3054,11 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
-			"dev": true
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/async-retry": {
 			"version": "1.3.3",
@@ -3091,37 +3069,43 @@
 				"retry": "0.13.1"
 			}
 		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/atomic-sleep": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
 			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+		"node_modules/atomically": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+			"integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
 			"dev": true,
 			"dependencies": {
-				"possible-typed-array-names": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"stubborn-fs": "^1.2.5",
+				"when-exit": "^2.1.1"
+			}
+		},
+		"node_modules/axios": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -3163,13 +3147,15 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
 			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.52",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
 			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
 			"dev": true,
+			"license": "Unlicense",
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -3227,13 +3213,15 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/bottleneck": {
 			"version": "2.19.5",
@@ -3292,6 +3280,7 @@
 			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
 			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"big-integer": "^1.6.44"
 			},
@@ -3340,6 +3329,7 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -3380,25 +3370,41 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/bumpp": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/bumpp/-/bumpp-9.4.1.tgz",
-			"integrity": "sha512-kzhp/LpNX0HkUpEyLd7sU2LTN/mbAVgcxJ1Zi2cAJTE/tul6rypSKGpH8UywDpzKWItL8LVdKsIFnwmylw0+7g==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/bumpp/-/bumpp-9.6.1.tgz",
+			"integrity": "sha512-lQlPfyS0GrO5FaOODK+OHQxfCT+6/xWfd3Zt8dzsmzm69RWQfh5fAU9igmeZWOzK/s+4vL+gQLo3yw474ntBZw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jsdevtools/ez-spawn": "^3.0.4",
-				"c12": "^1.10.0",
+				"c12": "^1.11.2",
 				"cac": "^6.7.14",
-				"escalade": "^3.1.2",
+				"escalade": "^3.2.0",
 				"fast-glob": "^3.3.2",
 				"js-yaml": "^4.1.0",
+				"jsonc-parser": "^3.3.1",
 				"prompts": "^2.4.2",
-				"semver": "^7.6.0"
+				"semver": "^7.6.3"
 			},
 			"bin": {
 				"bumpp": "bin/bumpp.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/bumpp/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -3409,6 +3415,7 @@
 			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
 			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"run-applescript": "^7.0.0"
 			},
@@ -3419,29 +3426,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/bunyan": {
-			"version": "1.8.15",
-			"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-			"integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-			"dev": true,
-			"engines": [
-				"node >=0.10.0"
-			],
-			"bin": {
-				"bunyan": "bin/bunyan"
-			},
-			"optionalDependencies": {
-				"dtrace-provider": "~0.8",
-				"moment": "^2.19.3",
-				"mv": "~2",
-				"safe-json-stringify": "~1"
-			}
-		},
 		"node_modules/c12": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/c12/-/c12-1.11.1.tgz",
-			"integrity": "sha512-KDU0TvSvVdaYcQKQ6iPHATGz/7p/KiVjPg4vQrB6Jg/wX9R0yl5RZxWm9IoZqaIHD2+6PZd81+KMGwRr/lRIUg==",
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-1.11.2.tgz",
+			"integrity": "sha512-oBs8a4uvSDO9dm8b7OCFW7+dgtVrwmwnrVXYzLm43ta7ep2jCn/0MhoUFygIWtxhyy6+/MG7/agvpY0U1Iemew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.6.0",
 				"confbox": "^0.1.7",
@@ -3453,7 +3443,7 @@
 				"ohash": "^1.1.3",
 				"pathe": "^1.1.2",
 				"perfect-debounce": "^1.0.0",
-				"pkg-types": "^1.1.1",
+				"pkg-types": "^1.2.0",
 				"rc9": "^2.1.2"
 			},
 			"peerDependencies": {
@@ -3470,73 +3460,17 @@
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-lookup": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-			"integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/cacheable-request": {
-			"version": "10.2.14",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-			"integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/http-cache-semantics": "^4.0.2",
-				"get-stream": "^6.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.3",
-				"mimic-response": "^4.0.0",
-				"normalize-url": "^8.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/call-bind": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"set-function-length": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/call-me-maybe": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
 			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -3601,6 +3535,7 @@
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
 			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cheerio-select": "^2.1.0",
 				"dom-serializer": "^2.0.0",
@@ -3622,6 +3557,7 @@
 			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
 			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0",
 				"css-select": "^5.1.0",
@@ -3680,15 +3616,16 @@
 			}
 		},
 		"node_modules/chrome-launcher": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
-			"integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.1.2.tgz",
+			"integrity": "sha512-YclTJey34KUm5jB1aEJCq807bSievi7Nb/TU4Gu504fUYi3jw3KCIaH6L7nFWQhdEgH3V+wCh+kKD1P5cXnfxw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "*",
 				"escape-string-regexp": "^4.0.0",
 				"is-wsl": "^2.2.0",
-				"lighthouse-logger": "^1.0.0"
+				"lighthouse-logger": "^2.0.1"
 			},
 			"bin": {
 				"print-chrome-path": "bin/print-chrome-path.js"
@@ -3702,6 +3639,7 @@
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -3717,24 +3655,10 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
 			"engines": {
 				"node": ">=8"
 			}
@@ -3744,6 +3668,7 @@
 			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
 			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"consola": "^3.2.3"
 			}
@@ -3765,6 +3690,7 @@
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
 			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"restore-cursor": "^3.1.0"
 			},
@@ -3885,12 +3811,26 @@
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
 			"integrity": "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"strip-ansi": "^6.0.1",
 				"wcwidth": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/commander": {
@@ -3907,6 +3847,7 @@
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
 			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -4027,6 +3968,7 @@
 			"engines": [
 				"node >= 0.8"
 			],
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -4039,6 +3981,7 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4053,28 +3996,32 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/concat-stream/node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/confbox": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
-			"integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
-			"dev": true
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/config-chain": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
 			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -4084,7 +4031,8 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/configstore": {
 			"version": "6.0.0",
@@ -4110,6 +4058,7 @@
 			"resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
 			"integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
 			}
@@ -4392,6 +4341,7 @@
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
 			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0",
 				"css-what": "^6.1.0",
@@ -4408,6 +4358,7 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
 			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">= 6"
 			},
@@ -4429,20 +4380,12 @@
 				"type": "^1.0.1"
 			}
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
 			"integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -4466,35 +4409,9 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
 			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decompress-response/node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4505,6 +4422,7 @@
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -4520,6 +4438,7 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4529,6 +4448,7 @@
 			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
 			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^4.1.0",
 				"default-browser-id": "^5.0.0"
@@ -4545,6 +4465,7 @@
 			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
 			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -4564,32 +4485,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/defer-to-connect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/define-data-property": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -4602,28 +4497,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/defu": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/degenerator": {
 			"version": "5.0.1",
@@ -4639,6 +4518,16 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -4649,13 +4538,15 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/destr": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
 			"integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/detect-libc": {
 			"version": "2.0.3",
@@ -4695,6 +4586,7 @@
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.2",
@@ -4714,13 +4606,15 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/fb55"
 				}
-			]
+			],
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"domelementtype": "^2.3.0"
 			},
@@ -4736,6 +4630,7 @@
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
 			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
@@ -4765,25 +4660,12 @@
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
 			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/dtrace-provider": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-			"integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"dependencies": {
-				"nan": "^2.14.0"
-			},
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -4812,6 +4694,7 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -4861,144 +4744,16 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"node_modules/es-abstract": {
-			"version": "1.22.4",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.4.tgz",
-			"integrity": "sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg==",
+		"node_modules/es-toolkit": {
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.23.0.tgz",
+			"integrity": "sha512-1Caq9T90fX973dnm8BIEBN9l9pffbxxbZYZYwIy/B4g8oFwNTMcbbqzvIWV4XVZlHY6A8RLZvI/3agxF0CmOPA==",
 			"dev": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.1",
-				"arraybuffer.prototype.slice": "^1.0.3",
-				"available-typed-arrays": "^1.0.6",
-				"call-bind": "^1.0.7",
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.2",
-				"es-to-primitive": "^1.2.1",
-				"function.prototype.name": "^1.1.6",
-				"get-intrinsic": "^1.2.4",
-				"get-symbol-description": "^1.0.2",
-				"globalthis": "^1.0.3",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.1",
-				"internal-slot": "^1.0.7",
-				"is-array-buffer": "^3.0.4",
-				"is-callable": "^1.2.7",
-				"is-negative-zero": "^2.0.2",
-				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
-				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.13",
-				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.13.1",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.5",
-				"regexp.prototype.flags": "^1.5.2",
-				"safe-array-concat": "^1.1.0",
-				"safe-regex-test": "^1.0.3",
-				"string.prototype.trim": "^1.2.8",
-				"string.prototype.trimend": "^1.0.7",
-				"string.prototype.trimstart": "^1.0.7",
-				"typed-array-buffer": "^1.0.1",
-				"typed-array-byte-length": "^1.0.0",
-				"typed-array-byte-offset": "^1.0.0",
-				"typed-array-length": "^1.0.4",
-				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-get-iterator": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
-				"has-symbols": "^1.0.3",
-				"is-arguments": "^1.1.1",
-				"is-map": "^2.0.2",
-				"is-set": "^2.0.2",
-				"is-string": "^1.0.7",
-				"isarray": "^2.0.5",
-				"stop-iteration-iterator": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es-get-iterator/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.2.4",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
 		"node_modules/es5-ext": {
 			"version": "0.10.63",
@@ -5019,7 +4774,8 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es6-iterator": {
 			"version": "2.0.3",
@@ -5431,10 +5187,11 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -5485,16 +5242,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.0",
-				"@humanwhocodes/config-array": "^0.11.14",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -5556,6 +5315,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.0.2.tgz",
 			"integrity": "sha512-Pry0S9YmHoz8NCEMRQh7N0Yexh2MYCNPIlrV52hTmS7qXnTghWsjXouF08bgsrrZqaW9tt1ZiK3j5NEmPE+EjQ==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"peerDependencies": {
 				"eslint": "^6 || ^7 || ^8"
 			}
@@ -5715,6 +5475,7 @@
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -5724,6 +5485,7 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -5867,7 +5629,8 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
 			"integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -5886,9 +5649,17 @@
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
 			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+			"integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -5904,6 +5675,7 @@
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pend": "~1.2.0"
 			}
@@ -5915,53 +5687,6 @@
 			"dev": true,
 			"dependencies": {
 				"pend": "^1.2.0"
-			}
-		},
-		"node_modules/fetch-blob": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"dependencies": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
-			}
-		},
-		"node_modules/figures": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^1.0.5"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/figures/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -6017,43 +5742,23 @@
 			}
 		},
 		"node_modules/firefox-profile": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.6.0.tgz",
-			"integrity": "sha512-I9rAm1w8U3CdhgO4EzTJsCvgcbvynZn9lOySkZf78wUdUIQH2w9QOKf3pAX+THt2XMSSR3kJSuM8P7bYux9j8g==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.7.0.tgz",
+			"integrity": "sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"adm-zip": "~0.5.x",
-				"fs-extra": "~9.0.1",
-				"ini": "~2.0.0",
-				"minimist": "^1.2.5",
-				"xml2js": "^0.5.0"
+				"fs-extra": "^11.2.0",
+				"ini": "^4.1.3",
+				"minimist": "^1.2.8",
+				"xml2js": "^0.6.2"
 			},
 			"bin": {
 				"firefox-profile": "lib/cli.js"
-			}
-		},
-		"node_modules/firefox-profile/node_modules/fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-			"dev": true,
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/firefox-profile/node_modules/universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/first-chunk-stream": {
@@ -6061,6 +5766,7 @@
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-3.0.0.tgz",
 			"integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -6090,20 +5796,33 @@
 			"integrity": "sha512-3VELfuWCLVzt5d2Gblk8qcqFro6nuwvxwMzHaENVDHI7rxcBRtMCwTk/E9FXcgh+82DSpavPNDueA9+RxXJoFg==",
 			"dev": true
 		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
 			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.3"
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-			"integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^4.0.1"
@@ -6120,6 +5839,7 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=14"
 			},
@@ -6127,25 +5847,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/form-data-encoder": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
 			"dev": true,
-			"engines": {
-				"node": ">= 14.17"
-			}
-		},
-		"node_modules/formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fetch-blob": "^3.1.2"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
 			},
 			"engines": {
-				"node": ">=12.20.0"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -6207,38 +5921,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/function.prototype.name": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"functions-have-names": "^1.2.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/functions-have-names": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/fx-runner": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.4.0.tgz",
 			"integrity": "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
 				"commander": "2.9.0",
 				"shell-quote": "1.7.3",
@@ -6256,6 +5944,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 			"integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-readlink": ">= 1.0.0"
 			},
@@ -6267,13 +5956,15 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
 			"integrity": "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/fx-runner/node_modules/which": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
 			"integrity": "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-absolute": "^0.1.7",
 				"isexe": "^1.1.1"
@@ -6344,25 +6035,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-			"dev": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/get-ready": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-ready/-/get-ready-1.0.0.tgz",
@@ -6379,23 +6051,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/get-symbol-description": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.5",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-uri": {
@@ -6427,6 +6082,7 @@
 			"resolved": "https://registry.npmjs.org/giget/-/giget-1.2.3.tgz",
 			"integrity": "sha512-8EHPljDvs7qKykr6uw8b+lqLiUc/vUg+KVTI0uND4s63TdsZM2Xus3mflvF0DDG9SiM4RlCkFGL+7aAjRmV7KA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"citty": "^0.1.6",
 				"consola": "^3.2.3",
@@ -6528,13 +6184,15 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/global-directory": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
 			"integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ini": "4.1.1"
 			},
@@ -6550,23 +6208,9 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
 			"integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/global-dirs": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
-			"integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
-			"dev": true,
-			"dependencies": {
-				"ini": "2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globals": {
@@ -6582,21 +6226,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/globalthis": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-			"integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-			"dev": true,
-			"dependencies": {
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/globby": {
@@ -6619,55 +6248,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/got": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-			"dev": true,
-			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
-				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
-		},
-		"node_modules/got/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -6678,7 +6258,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -6690,7 +6271,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
@@ -6713,15 +6295,6 @@
 				"uglify-js": "^3.1.4"
 			}
 		},
-		"node_modules/has-bigints": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6731,74 +6304,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/has-property-descriptors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-proto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
 			"optional": true
-		},
-		"node_modules/has-yarn": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz",
-			"integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/hasown": {
 			"version": "2.0.1",
@@ -6830,12 +6340,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true
-		},
 		"node_modules/htmlparser2": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -6848,18 +6352,13 @@
 					"url": "https://github.com/sponsors/fb55"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
 			}
-		},
-		"node_modules/http-cache-semantics": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"dev": true
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -6872,19 +6371,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/http2-wrapper": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-			"integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-			"dev": true,
-			"dependencies": {
-				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -6955,6 +6441,7 @@
 			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
 			"integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"queue": "6.0.2"
 			},
@@ -7032,35 +6519,34 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
-				"node": ">=10"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "9.2.14",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.14.tgz",
-			"integrity": "sha512-4ByIMt677Iz5AvjyKrDpzaepIyMewNvDcvwpVVRZNmy9dLakVoVgdCHZXbK1SlVJra1db0JZ6XkJyHsanpdrdQ==",
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.2.tgz",
+			"integrity": "sha512-+ynEbhWKhyomnaX0n2aLIMSkgSlGB5RrWbNXnEqj6mdaIydu6y40MdBjL38SAB0JcdmOaIaMua1azdjLEr3sdw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@ljharb/through": "^2.3.12",
+				"@inquirer/figures": "^1.0.3",
 				"ansi-escapes": "^4.3.2",
-				"chalk": "^5.3.0",
-				"cli-cursor": "^3.1.0",
 				"cli-width": "^4.1.0",
 				"external-editor": "^3.1.0",
-				"figures": "^3.2.0",
-				"lodash": "^4.17.21",
 				"mute-stream": "1.0.0",
 				"ora": "^5.4.1",
 				"run-async": "^3.0.0",
 				"rxjs": "^7.8.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^6.2.0"
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -7071,35 +6557,26 @@
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"node_modules/inquirer/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/inquirer/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/inquirer/node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
 			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -7109,6 +6586,7 @@
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -7121,6 +6599,7 @@
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
 			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -7132,27 +6611,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/inquirer/node_modules/log-symbols/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/inquirer/node_modules/ora": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
 			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"bl": "^4.1.0",
 				"chalk": "^4.1.0",
@@ -7171,27 +6635,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/inquirer/node_modules/ora/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/inquirer/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -7206,6 +6655,7 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
 			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -7213,20 +6663,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/internal-slot": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-			"dev": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"hasown": "^2.0.0",
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/interpret": {
@@ -7243,6 +6679,7 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
 			"integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -7268,6 +6705,7 @@
 			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
 			"integrity": "sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-relative": "^0.1.0"
 			},
@@ -7275,55 +6713,11 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-array-buffer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
-		},
-		"node_modules/is-bigint": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
-			"dependencies": {
-				"has-bigints": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -7337,46 +6731,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-boolean-object": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
-			}
-		},
 		"node_modules/is-core-module": {
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -7384,21 +6738,6 @@
 			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-date-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -7483,16 +6822,30 @@
 			}
 		},
 		"node_modules/is-installed-globally": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+			"integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"global-dirs": "^3.0.0",
-				"is-path-inside": "^3.0.2"
+				"global-directory": "^4.0.1",
+				"is-path-inside": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-installed-globally/node_modules/is-path-inside": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7508,33 +6861,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-mergeable-object": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
-			"integrity": "sha512-CPduJfuGg8h8vW74WOxHtHmtQutyQBzR+3MjQ6iDHIYdbOnm1YC7jv43SqCoU8OPGTJD4nibmiryA4kmogbGrA==",
-			"dev": true
-		},
-		"node_modules/is-negative-zero": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-npm": {
@@ -7558,21 +6884,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-number-object": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -7591,22 +6902,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-regex": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-relative": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
@@ -7614,30 +6909,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-set": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-ssh": {
@@ -7659,51 +6930,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-string": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-symbol": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
-			"dependencies": {
-				"has-symbols": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-			"dev": true,
-			"dependencies": {
-				"which-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typedarray": {
@@ -7728,25 +6954,15 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
-			"dev": true
-		},
-		"node_modules/is-weakref": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "MIT"
 		},
 		"node_modules/is-wsl": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
 			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-inside-container": "^1.0.0"
 			},
@@ -7755,15 +6971,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-yarn-global": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
-			"integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/isarray": {
@@ -7778,10 +6985,11 @@
 			"dev": true
 		},
 		"node_modules/issue-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
-			"integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
+			"integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"lodash.capitalize": "^4.2.1",
 				"lodash.escaperegexp": "^4.1.2",
@@ -7790,29 +6998,7 @@
 				"lodash.uniqby": "^4.7.0"
 			},
 			"engines": {
-				"node": ">=10.13"
-			}
-		},
-		"node_modules/iterate-iterator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
-			"integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/iterate-value": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-			"dev": true,
-			"dependencies": {
-				"es-get-iterator": "^1.0.2",
-				"iterate-iterator": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": "^18.17 || >=20.6.1"
 			}
 		},
 		"node_modules/jackspeak": {
@@ -7820,6 +7006,7 @@
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
 			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
 			},
@@ -7834,22 +7021,25 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
 			"integrity": "sha512-z35ZSEcXHxLW4yumw0dF6L464NT36vmx3wxJw8MDpraBcWuNVgUPZgPJKcu1HekNgwlMFNqol7i/IpSbjhqwqA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jiti": {
 			"version": "1.21.6",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
 			"integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
 		},
 		"node_modules/jose": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-5.4.1.tgz",
-			"integrity": "sha512-U6QajmpV/nhL9SyfAewo000fkiRQ+Yd2H0lBxJJ9apjpOgkOcBQJWOrMo917lxLptdS/n/o/xPzMkXhF46K8hQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-5.9.2.tgz",
+			"integrity": "sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
@@ -7878,17 +7068,12 @@
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
 			"dev": true
 		},
-		"node_modules/json-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
-		},
 		"node_modules/json-merge-patch": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-1.0.2.tgz",
 			"integrity": "sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			}
@@ -7903,13 +7088,21 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -7966,29 +7159,22 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"node_modules/keyv": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-			"dev": true,
-			"dependencies": {
-				"json-buffer": "3.0.1"
-			}
-		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/ky": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ky/-/ky-1.4.0.tgz",
-			"integrity": "sha512-tPhhoGUiEiU/WXR4rt8klIoLdnTtyu+9jVKHd/wauEjYud32jyn63mzKWQweaQrHWxBQtYoVtdcEnYX1LosnFQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/ky/-/ky-1.7.2.tgz",
+			"integrity": "sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -7997,15 +7183,16 @@
 			}
 		},
 		"node_modules/latest-version": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
-			"integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+			"integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"package-json": "^8.1.0"
+				"package-json": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8016,6 +7203,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-3.1.1.tgz",
 			"integrity": "sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"invert-kv": "^3.0.0"
 			},
@@ -8045,10 +7233,11 @@
 			}
 		},
 		"node_modules/lighthouse-logger": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
-			"integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.1.tgz",
+			"integrity": "sha512-ioBrW3s2i97noEmnXxmUq7cjIcVRjT5HBpAYy8zE11CxU9HqlWHHeRxfeN1tn8F7OEMVPIC9x1f8t3Z7US9ehQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"debug": "^2.6.9",
 				"marky": "^1.2.2"
@@ -8059,6 +7248,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -8067,7 +7257,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
@@ -8115,25 +7306,29 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
 			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -8145,7 +7340,8 @@
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
 			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/log-symbols": {
 			"version": "6.0.0",
@@ -8187,29 +7383,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lowercase-keys": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"devOptional": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/macos-release": {
 			"version": "3.2.0",
@@ -8251,13 +7430,15 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-defer": "^1.0.0"
 			},
@@ -8274,13 +7455,15 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
 			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/mem": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
 			"integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"map-age-cleaner": "^0.1.3",
 				"mimic-fn": "^2.1.0",
@@ -8375,18 +7558,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-			"integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8455,25 +7626,16 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
-			"integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.2.tgz",
+			"integrity": "sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"acorn": "^8.11.3",
+				"acorn": "^8.12.1",
 				"pathe": "^1.1.2",
-				"pkg-types": "^1.1.1",
-				"ufo": "^1.5.3"
-			}
-		},
-		"node_modules/moment": {
-			"version": "2.30.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-			"dev": true,
-			"optional": true,
-			"engines": {
-				"node": "*"
+				"pkg-types": "^1.2.0",
+				"ufo": "^1.5.4"
 			}
 		},
 		"node_modules/ms": {
@@ -8487,6 +7649,7 @@
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-6.0.0.tgz",
 			"integrity": "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/minimatch": "^3.0.5",
 				"array-differ": "^4.0.0",
@@ -8505,6 +7668,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
 			"integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8521,77 +7685,6 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/mv": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-			"integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"mkdirp": "~0.5.1",
-				"ncp": "~2.0.0",
-				"rimraf": "~2.4.0"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/mv/node_modules/glob": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-			"integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "2 || 3",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/mv/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/mv/node_modules/rimraf": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-			"integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"glob": "^6.0.1"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/mz": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-			"dev": true,
-			"dependencies": {
-				"any-promise": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"thenify-all": "^1.0.0"
-			}
-		},
 		"node_modules/nan": {
 			"version": "2.20.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
@@ -8603,16 +7696,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/ncp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-			"integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-			"dev": true,
-			"optional": true,
-			"bin": {
-				"ncp": "bin/ncp"
-			}
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -8661,54 +7744,19 @@
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
 			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-			"dev": true,
-			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
-			}
-		},
 		"node_modules/node-fetch-native": {
 			"version": "1.6.4",
 			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
 			"integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
 			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
 			"dev": true,
+			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"engines": {
 				"node": ">= 6.13.0"
 			}
@@ -8718,6 +7766,7 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
 			"integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"growly": "^1.3.0",
 				"is-wsl": "^2.2.0",
@@ -8732,6 +7781,7 @@
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -8747,6 +7797,7 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -8790,18 +7841,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/normalize-url": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-			"integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -8849,6 +7888,7 @@
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
 			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0"
 			},
@@ -8857,17 +7897,18 @@
 			}
 		},
 		"node_modules/nypm": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.3.9.tgz",
-			"integrity": "sha512-BI2SdqqTHg2d4wJh8P9A1W+bslg33vOE9IZDY6eR2QC+Pu1iNBVZUqczrd43rJb+fMzHU7ltAYKsEFY/kHMFcw==",
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.3.12.tgz",
+			"integrity": "sha512-D3pzNDWIvgA+7IORhD/IuWzEk4uXv6GsgOxiid4UU3h9oq5IqV1KtPDi63n4sZJ/xcWlr88c0QM2RgN5VbOhFA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"citty": "^0.1.6",
 				"consola": "^3.2.3",
 				"execa": "^8.0.1",
 				"pathe": "^1.1.2",
-				"pkg-types": "^1.1.1",
-				"ufo": "^1.5.3"
+				"pkg-types": "^1.2.0",
+				"ufo": "^1.5.4"
 			},
 			"bin": {
 				"nypm": "dist/cli.mjs"
@@ -8880,45 +7921,9 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"devOptional": true,
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.5",
-				"define-properties": "^1.2.1",
-				"has-symbols": "^1.0.3",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/octokit": {
@@ -8995,12 +8000,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/octokit/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true
 		},
 		"node_modules/octokit/node_modules/@octokit/plugin-paginate-graphql": {
 			"version": "5.2.2",
@@ -9104,15 +8103,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/octokit/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/octokit/node_modules/before-after-hook": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
@@ -9126,16 +8116,18 @@
 			"dev": true
 		},
 		"node_modules/ohash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
-			"integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==",
-			"dev": true
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+			"integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/on-exit-leak-free": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
 			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -9165,10 +8157,11 @@
 			}
 		},
 		"node_modules/open": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.0.3.tgz",
-			"integrity": "sha512-dtbI5oW7987hwC9qjJTyABldTaa19SuyJse1QboWv3b0qCcrrLNVDqBx1XgELAjh9QTVQaP/C5b1nhQebd1H2A==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"default-browser": "^5.2.1",
 				"define-lazy-prop": "^3.0.0",
@@ -9320,6 +8313,7 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
 			"integrity": "sha512-tqZcNEDAIZKBEPnHPlVDvKrp7NzgLi7jRmhKiUoa2NUmhl13FtkAGLUVR+ZsYvApBQdBfYm43A4tXXQ4IrYLBA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"execa": "^4.0.0",
 				"lcid": "^3.0.0",
@@ -9337,6 +8331,7 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
 			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
 				"get-stream": "^5.0.0",
@@ -9360,6 +8355,7 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -9375,6 +8371,7 @@
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
 			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.12.0"
 			}
@@ -9384,6 +8381,7 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -9396,6 +8394,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
 			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.0.0"
 			},
@@ -9408,6 +8407,7 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -9446,20 +8446,12 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/p-cancelable": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
 		"node_modules/p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -9469,6 +8461,7 @@
 			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
 			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -9536,65 +8529,30 @@
 			}
 		},
 		"node_modules/package-json": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
-			"integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+			"integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"got": "^12.1.0",
-				"registry-auth-token": "^5.0.1",
-				"registry-url": "^6.0.0",
-				"semver": "^7.3.7"
+				"ky": "^1.2.0",
+				"registry-auth-token": "^5.0.2",
+				"registry-url": "^6.0.1",
+				"semver": "^7.6.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/package-json-from-dist": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-			"dev": true
-		},
-		"node_modules/package-json/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/package-json/node_modules/got": {
-			"version": "12.6.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-			"integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
-			"dev": true,
-			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
-				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
+			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -9649,6 +8607,7 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
 			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"entities": "^4.4.0"
 			},
@@ -9661,6 +8620,7 @@
 			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
 			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"domhandler": "^5.0.2",
 				"parse5": "^7.0.0"
@@ -9707,6 +8667,7 @@
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
 			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9717,12 +8678,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -9751,7 +8706,8 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
 			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pdfjs-dist": {
 			"version": "4.4.168",
@@ -9775,7 +8731,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
 			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -9790,22 +8747,23 @@
 			}
 		},
 		"node_modules/pino": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-8.20.0.tgz",
-			"integrity": "sha512-uhIfMj5TVp+WynVASaVEJFTncTUe4dHBq6CWplu/vBgvGHhvBvQfxz+vcOrnnBQdORH3izaGEurLfNlq3YxdFQ==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
+			"integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0",
 				"fast-redact": "^3.1.1",
 				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^1.1.0",
-				"pino-std-serializers": "^6.0.0",
-				"process-warning": "^3.0.0",
+				"pino-abstract-transport": "^1.2.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^4.0.0",
 				"quick-format-unescaped": "^4.0.3",
 				"real-require": "^0.2.0",
 				"safe-stable-stringify": "^2.3.1",
-				"sonic-boom": "^3.7.0",
-				"thread-stream": "^2.0.0"
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
 			},
 			"bin": {
 				"pino": "bin.js"
@@ -9816,6 +8774,7 @@
 			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
 			"integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"readable-stream": "^4.0.0",
 				"split2": "^4.0.0"
@@ -9840,6 +8799,7 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
@@ -9850,6 +8810,7 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
 			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -9862,29 +8823,22 @@
 			}
 		},
 		"node_modules/pino-std-serializers": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-			"dev": true
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pkg-types": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.3.tgz",
-			"integrity": "sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
+			"integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.1.7",
 				"mlly": "^1.7.1",
 				"pathe": "^1.1.2"
-			}
-		},
-		"node_modules/possible-typed-array-names": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -9916,6 +8870,7 @@
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -9926,16 +8881,18 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"node_modules/process-warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-			"integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
+			"integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/promise-toolbox": {
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
 			"integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"make-error": "^1.3.2"
 			},
@@ -9943,31 +8900,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/promise.allsettled": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
-			"integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
-			"dev": true,
-			"dependencies": {
-				"array.prototype.map": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"get-intrinsic": "^1.2.1",
-				"iterate-value": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
 			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
@@ -9980,7 +8918,8 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/protocols": {
 			"version": "2.0.1",
@@ -10061,6 +9000,7 @@
 			"resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
 			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "~2.0.3"
 			}
@@ -10089,34 +9029,15 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
 			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-			"dev": true
-		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/radash": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/radash/-/radash-12.1.0.tgz",
-			"integrity": "sha512-b0Zcf09AhqKS83btmUeYBS8tFK7XL2e3RvLmZcm0sTdF1/UUlHSsjXdCcWNxe7yfmAlPve5ym0DmKGtTzP6kVQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.18.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -10131,13 +9052,15 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/rc/node_modules/strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10147,6 +9070,7 @@
 			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
 			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"defu": "^6.1.4",
 				"destr": "^2.0.3"
@@ -10260,6 +9184,7 @@
 			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
 			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 12.13.0"
 			}
@@ -10280,31 +9205,15 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
 			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.6",
-				"define-properties": "^1.2.1",
-				"es-errors": "^1.3.0",
-				"set-function-name": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "MIT"
 		},
 		"node_modules/registry-auth-token": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
 			"integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@pnpm/npm-conf": "^2.1.0"
 			},
@@ -10317,6 +9226,7 @@
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
 			"integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"rc": "1.2.8"
 			},
@@ -10332,6 +9242,7 @@
 			"resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
 			"integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"chalk": "^2.4.2",
 				"commander": "^2.6.0"
@@ -10348,6 +9259,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -10360,6 +9272,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -10374,6 +9287,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -10382,19 +9296,22 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/relaxed-json/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/relaxed-json/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -10404,6 +9321,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -10413,6 +9331,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -10421,9 +9340,9 @@
 			}
 		},
 		"node_modules/release-it": {
-			"version": "17.1.1",
-			"resolved": "https://registry.npmjs.org/release-it/-/release-it-17.1.1.tgz",
-			"integrity": "sha512-b+4Tu2eb5f2wIdIe5E9hre0evbMQrXp/kRq0natHsHYJVqu1Bd4/h2a+swFi0faGmC3cJdB16uYR6LscG9SchQ==",
+			"version": "17.7.0",
+			"resolved": "https://registry.npmjs.org/release-it/-/release-it-17.7.0.tgz",
+			"integrity": "sha512-VL9nBetoLf5k/QiMhtmit762nUAAMyrzjHbqU8z9iwUb7M8NhZjrbMU8rxcEJCWrSNlvsnn2lEbcWBeg/IEI8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -10435,40 +9354,38 @@
 					"url": "https://opencollective.com/webpro"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"@iarna/toml": "2.2.5",
-				"@octokit/rest": "20.0.2",
+				"@octokit/rest": "20.1.1",
 				"async-retry": "1.3.3",
 				"chalk": "5.3.0",
+				"ci-info": "^4.0.0",
 				"cosmiconfig": "9.0.0",
 				"execa": "8.0.1",
 				"git-url-parse": "14.0.0",
-				"globby": "14.0.1",
-				"got": "13.0.0",
-				"inquirer": "9.2.14",
-				"is-ci": "3.0.1",
-				"issue-parser": "6.0.0",
+				"globby": "14.0.2",
+				"inquirer": "9.3.2",
+				"issue-parser": "7.0.1",
 				"lodash": "4.17.21",
 				"mime-types": "2.1.35",
 				"new-github-release-url": "2.0.0",
-				"node-fetch": "3.3.2",
-				"open": "10.0.3",
+				"open": "10.1.0",
 				"ora": "8.0.1",
 				"os-name": "5.1.0",
-				"promise.allsettled": "1.0.7",
 				"proxy-agent": "6.4.0",
-				"semver": "7.6.0",
+				"semver": "7.6.2",
 				"shelljs": "0.8.5",
-				"update-notifier": "7.0.0",
+				"update-notifier": "7.1.0",
 				"url-join": "5.0.0",
-				"wildcard-match": "5.1.2",
+				"wildcard-match": "5.1.3",
 				"yargs-parser": "21.1.1"
 			},
 			"bin": {
 				"release-it": "bin/release-it.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^18.18.0 || ^20.9.0 || ^22.0.0"
 			}
 		},
 		"node_modules/release-it/node_modules/chalk": {
@@ -10483,11 +9400,28 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/release-it/node_modules/globby": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
-			"integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+		"node_modules/release-it/node_modules/ci-info": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+			"integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/release-it/node_modules/globby": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^2.1.0",
 				"fast-glob": "^3.3.2",
@@ -10508,6 +9442,7 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
 			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -10520,6 +9455,7 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
 			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -10598,6 +9534,7 @@
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10619,12 +9556,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/resolve-alpn": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-			"dev": true
-		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -10634,26 +9565,12 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/responselike": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-			"integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-			"dev": true,
-			"dependencies": {
-				"lowercase-keys": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
 			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
@@ -10701,6 +9618,7 @@
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
 			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -10713,6 +9631,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
 			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -10745,33 +9664,10 @@
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
 			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
-		},
-		"node_modules/safe-array-concat": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
-			"integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.5",
-				"get-intrinsic": "^1.2.2",
-				"has-symbols": "^1.0.3",
-				"isarray": "^2.0.5"
-			},
-			"engines": {
-				"node": ">=0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-array-concat/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -10793,35 +9689,12 @@
 				}
 			]
 		},
-		"node_modules/safe-json-stringify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-			"integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-			"dev": true,
-			"optional": true
-		},
-		"node_modules/safe-regex-test": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.6",
-				"es-errors": "^1.3.0",
-				"is-regex": "^1.1.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -10836,16 +9709,15 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"devOptional": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -10874,55 +9746,10 @@
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"optional": true
 		},
-		"node_modules/set-function-length": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.1.2",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.3",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-function-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"functions-have-names": "^1.2.3",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-		},
-		"node_modules/sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			},
-			"bin": {
-				"sha.js": "bin.js"
-			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -10949,7 +9776,8 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
 			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/shelljs": {
 			"version": "0.8.5",
@@ -10972,25 +9800,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
-		},
-		"node_modules/side-channel": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-			"integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
 			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.6",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"object-inspect": "^1.13.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "MIT"
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
@@ -11057,7 +9868,8 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -11107,10 +9919,11 @@
 			}
 		},
 		"node_modules/sonic-boom": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-			"integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
+			"integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
 			}
@@ -11129,6 +9942,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -11140,6 +9954,7 @@
 			"integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"concat-stream": "^1.4.7",
 				"os-shim": "^0.1.2"
@@ -11182,6 +9997,7 @@
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"through": "2"
 			},
@@ -11194,6 +10010,7 @@
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -11222,18 +10039,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/stop-iteration-iterator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-			"dev": true,
-			"dependencies": {
-				"internal-slot": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/streamifier": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
@@ -11257,6 +10062,7 @@
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
 			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.19"
 			}
@@ -11284,6 +10090,7 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -11297,7 +10104,8 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "6.0.1",
@@ -11326,51 +10134,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/string.prototype.trim": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimend": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -11389,6 +10152,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -11401,6 +10165,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
 			"integrity": "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -11413,6 +10178,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
 			"integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-utf8": "^0.2.1"
 			},
@@ -11425,6 +10191,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-4.0.0.tgz",
 			"integrity": "sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"first-chunk-stream": "^3.0.0",
 				"strip-bom-buf": "^2.0.0"
@@ -11456,6 +10223,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/stubborn-fs": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+			"integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
+			"dev": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -11504,32 +10277,12 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
-		"node_modules/thenify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-			"dev": true,
-			"dependencies": {
-				"any-promise": "^1.0.0"
-			}
-		},
-		"node_modules/thenify-all": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-			"dev": true,
-			"dependencies": {
-				"thenify": ">= 3.1.0 < 4"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/thread-stream": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-			"integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+			"integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"real-require": "^0.2.0"
 			}
@@ -11538,13 +10291,15 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/titleize": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
 			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -11580,15 +10335,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/tosource": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tosource/-/tosource-1.0.0.tgz",
-			"integrity": "sha512-N6g8eQ1eerw6Y1pBhdgkubWIiPFwXa2POSUrlL8jth5CyyEWNWzoGKRkO3CaO7Jx27hlJP54muB3btIAbx4MPg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/tr46": {
@@ -11633,10 +10379,11 @@
 			}
 		},
 		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -11653,84 +10400,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typed-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"es-errors": "^1.3.0",
-				"is-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/typed-array-byte-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-proto": "^1.0.3",
-				"is-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-byte-offset": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-proto": "^1.0.3",
-				"is-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-length": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
-			"integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-proto": "^1.0.3",
-				"is-typed-array": "^1.1.13",
-				"possible-typed-array-names": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -11742,10 +10417,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11758,7 +10434,8 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
 			"integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uglify-js": {
 			"version": "3.19.0",
@@ -11771,21 +10448,6 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/unbox-primitive": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-bigints": "^1.0.2",
-				"has-symbols": "^1.0.3",
-				"which-boxed-primitive": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/undici-types": {
@@ -11831,7 +10493,8 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
 			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
@@ -11847,6 +10510,7 @@
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
 			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -11856,27 +10520,29 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
 			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4",
 				"yarn": "*"
 			}
 		},
 		"node_modules/update-notifier": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.0.0.tgz",
-			"integrity": "sha512-Hv25Bh+eAbOLlsjJreVPOs4vd51rrtCrmhyOJtbpAojro34jS4KQaEp4/EvlHJX7jSO42VvEFpkastVyXyIsdQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.1.0.tgz",
+			"integrity": "sha512-8SV3rIqVY6EFC1WxH6L0j55s0MO79MFBS1pivmInRJg3pCEDgWHBj1Q6XByTtCLOZIFA0f6zoG9ZWf2Ks9lvTA==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boxen": "^7.1.1",
 				"chalk": "^5.3.0",
 				"configstore": "^6.0.0",
 				"import-lazy": "^4.0.0",
 				"is-in-ci": "^0.1.0",
-				"is-installed-globally": "^0.4.0",
+				"is-installed-globally": "^1.0.0",
 				"is-npm": "^6.0.0",
-				"latest-version": "^7.0.0",
+				"latest-version": "^9.0.0",
 				"pupa": "^3.1.0",
-				"semver": "^7.5.4",
+				"semver": "^7.6.2",
 				"semver-diff": "^4.0.0",
 				"xdg-basedir": "^5.1.0"
 			},
@@ -11892,6 +10558,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
 			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -11927,6 +10594,7 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -11942,10 +10610,11 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-			"integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -11964,41 +10633,38 @@
 			}
 		},
 		"node_modules/web-ext": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/web-ext/-/web-ext-8.2.0.tgz",
-			"integrity": "sha512-krU7rmxaG96b3Q9Enbry9/pmE/5FUGkvajCGfJCD+J79rt7JFjhVpw1Dszz4BqQkTd3y8cG5wJ3p1uC6uyAwcA==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/web-ext/-/web-ext-8.3.0.tgz",
+			"integrity": "sha512-mXSOiDtmm3n0KNpSuQ65fJpypAoNLAmZv3QkdlVbJ6etn0BK+hl/k+tjHefSIKdbzGUIeFbhn2oxWMe9Tdyrdg==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
-				"@babel/runtime": "7.24.7",
+				"@babel/runtime": "7.25.6",
 				"@devicefarmer/adbkit": "3.2.6",
-				"addons-linter": "6.31.1",
-				"bunyan": "1.8.15",
+				"addons-linter": "7.1.0",
 				"camelcase": "8.0.0",
-				"chrome-launcher": "0.15.1",
+				"chrome-launcher": "1.1.2",
 				"debounce": "1.2.1",
 				"decamelize": "6.0.0",
 				"es6-error": "4.1.1",
-				"firefox-profile": "4.6.0",
-				"fs-extra": "11.2.0",
+				"firefox-profile": "4.7.0",
 				"fx-runner": "1.4.0",
 				"https-proxy-agent": "^7.0.0",
-				"jose": "5.4.1",
+				"jose": "5.9.2",
 				"jszip": "3.10.1",
-				"mkdirp": "3.0.1",
 				"multimatch": "6.0.0",
-				"mz": "2.7.0",
-				"node-fetch": "3.3.2",
 				"node-notifier": "10.0.1",
 				"open": "9.1.0",
 				"parse-json": "7.1.1",
+				"pino": "9.4.0",
 				"promise-toolbox": "0.21.0",
 				"source-map-support": "0.5.21",
 				"strip-bom": "5.0.0",
 				"strip-json-comments": "5.0.1",
 				"tmp": "0.2.3",
-				"update-notifier": "6.0.2",
-				"watchpack": "2.4.1",
-				"ws": "8.17.1",
+				"update-notifier": "7.3.1",
+				"watchpack": "2.4.2",
+				"ws": "8.18.0",
 				"yargs": "17.7.2",
 				"zip-dir": "2.0.0"
 			},
@@ -12010,11 +10676,74 @@
 				"npm": ">=8.0.0"
 			}
 		},
+		"node_modules/web-ext/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/web-ext/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/web-ext/node_modules/boxen": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+			"integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-align": "^3.0.1",
+				"camelcase": "^8.0.0",
+				"chalk": "^5.3.0",
+				"cli-boxes": "^3.0.0",
+				"string-width": "^7.2.0",
+				"type-fest": "^4.21.0",
+				"widest-line": "^5.0.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/web-ext/node_modules/boxen/node_modules/type-fest": {
+			"version": "4.26.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+			"integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/web-ext/node_modules/bundle-name": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
 			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"run-applescript": "^5.0.0"
 			},
@@ -12030,6 +10759,7 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
 			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			},
@@ -12042,6 +10772,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
 			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -12049,11 +10780,31 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/web-ext/node_modules/configstore": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.0.0.tgz",
+			"integrity": "sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"atomically": "^2.0.3",
+				"dot-prop": "^9.0.0",
+				"graceful-fs": "^4.2.11",
+				"xdg-basedir": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/yeoman/configstore?sponsor=1"
+			}
+		},
 		"node_modules/web-ext/node_modules/default-browser": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
 			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^3.0.0",
 				"default-browser-id": "^3.0.0",
@@ -12072,6 +10823,7 @@
 			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
 			"integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"bplist-parser": "^0.2.0",
 				"untildify": "^4.0.0"
@@ -12083,11 +10835,48 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/web-ext/node_modules/dot-prop": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+			"integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^4.18.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/web-ext/node_modules/dot-prop/node_modules/type-fest": {
+			"version": "4.26.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+			"integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/web-ext/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/web-ext/node_modules/execa": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
 			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.1",
@@ -12111,6 +10900,7 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -12118,11 +10908,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/web-ext/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/web-ext/node_modules/human-signals": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
 			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14.18.0"
 			}
@@ -12132,6 +10930,7 @@
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -12142,11 +10941,28 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/web-ext/node_modules/is-in-ci": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+			"integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-in-ci": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/web-ext/node_modules/is-wsl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -12159,6 +10975,7 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
 			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
@@ -12168,6 +10985,7 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
 			"integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
@@ -12177,6 +10995,7 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
 			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -12184,26 +11003,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/web-ext/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-			"dev": true,
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/web-ext/node_modules/onetime": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
 			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^4.0.0"
 			},
@@ -12219,6 +11024,7 @@
 			"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
 			"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"default-browser": "^4.0.0",
 				"define-lazy-prop": "^3.0.0",
@@ -12237,6 +11043,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
 			"integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.21.4",
 				"error-ex": "^1.3.2",
@@ -12256,6 +11063,7 @@
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
 			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.0.0"
 			},
@@ -12271,6 +11079,7 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
 			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.0",
@@ -12294,6 +11103,7 @@
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.17.0"
 			}
@@ -12303,6 +11113,7 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -12315,6 +11126,7 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -12324,6 +11136,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
 			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.0.0"
 			},
@@ -12336,6 +11149,7 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
 			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^2.1.0"
 			},
@@ -12351,8 +11165,56 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/web-ext/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/web-ext/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/web-ext/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/web-ext/node_modules/strip-json-comments": {
@@ -12360,6 +11222,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
 			"integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -12372,6 +11235,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
 			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.14"
 			}
@@ -12381,6 +11245,7 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
 			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
 			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -12389,40 +11254,62 @@
 			}
 		},
 		"node_modules/web-ext/node_modules/update-notifier": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-6.0.2.tgz",
-			"integrity": "sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+			"integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"boxen": "^7.0.0",
-				"chalk": "^5.0.1",
-				"configstore": "^6.0.0",
-				"has-yarn": "^3.0.0",
-				"import-lazy": "^4.0.0",
-				"is-ci": "^3.0.1",
-				"is-installed-globally": "^0.4.0",
+				"boxen": "^8.0.1",
+				"chalk": "^5.3.0",
+				"configstore": "^7.0.0",
+				"is-in-ci": "^1.0.0",
+				"is-installed-globally": "^1.0.0",
 				"is-npm": "^6.0.0",
-				"is-yarn-global": "^0.4.0",
-				"latest-version": "^7.0.0",
+				"latest-version": "^9.0.0",
 				"pupa": "^3.1.0",
-				"semver": "^7.3.7",
-				"semver-diff": "^4.0.0",
+				"semver": "^7.6.3",
 				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
 			}
 		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+		"node_modules/web-ext/node_modules/widest-line": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+			"integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^7.0.0"
+			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/web-ext/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -12445,6 +11332,13 @@
 			"version": "3.7.7",
 			"resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
 			"integrity": "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/when-exit": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.3.tgz",
+			"integrity": "sha512-uVieSTccFIr/SFQdFWN/fFaQYmV37OKtuaGphMAzi4DmmUlrvRBJW5WSLkHyjNQY/ePJMz3LoiX9R3yy1Su6Hw==",
 			"dev": true
 		},
 		"node_modules/which": {
@@ -12460,41 +11354,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-boxed-primitive": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
-			"dependencies": {
-				"is-bigint": "^1.0.1",
-				"is-boolean-object": "^1.1.0",
-				"is-number-object": "^1.0.4",
-				"is-string": "^1.0.5",
-				"is-symbol": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-			"integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.6",
-				"call-bind": "^1.0.5",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/wide-align": {
@@ -12542,10 +11401,11 @@
 			}
 		},
 		"node_modules/wildcard-match": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.2.tgz",
-			"integrity": "sha512-qNXwI591Z88c8bWxp+yjV60Ch4F8Riawe3iGxbzquhy8Xs9m+0+SLFBGb/0yCTIDElawtaImC37fYZ+dr32KqQ==",
-			"dev": true
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.3.tgz",
+			"integrity": "sha512-a95hPUk+BNzSGLntNXYxsjz2Hooi5oL7xOfJR6CKwSsSALh7vUNuTlzsrZowtYy38JNduYFRVhFv19ocqNOZlg==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/windows-release": {
 			"version": "5.1.1",
@@ -12643,7 +11503,8 @@
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
 			"integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD"
 		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
@@ -12674,6 +11535,7 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -12690,13 +11552,15 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -12764,10 +11628,11 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -12797,10 +11662,11 @@
 			}
 		},
 		"node_modules/xml2js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -12814,6 +11680,7 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -12894,6 +11761,7 @@
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
@@ -12937,36 +11805,39 @@
 			"resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-2.0.0.tgz",
 			"integrity": "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"async": "^3.2.0",
 				"jszip": "^3.2.2"
 			}
 		},
 		"node_modules/zotero-plugin-scaffold": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/zotero-plugin-scaffold/-/zotero-plugin-scaffold-0.0.33.tgz",
-			"integrity": "sha512-ROU+zrCY0yxAVUVIMG7O9ItNz/BZYtSJn0R3Pin9LLxzSLWIQYxmfhFkY5OkIgN6NgaBjWfu+VpWKrchW9aBQQ==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/zotero-plugin-scaffold/-/zotero-plugin-scaffold-0.1.6.tgz",
+			"integrity": "sha512-/wNwIV54oYQz8uqA1PnQOpldAJ/G45NFdnYUPeD4W/eTqG324jUONq8hspIzQZ4R3zLLZqmKueHFM1Sc1bqdRA==",
 			"dev": true,
+			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"@inquirer/prompts": "5.2.0",
-				"bumpp": "9.4.1",
-				"c12": "1.11.1",
-				"chalk": "5.3.0",
-				"chokidar": "3.6.0",
-				"commander": "12.1.0",
-				"consola": "3.2.3",
-				"conventional-changelog": "6.0.0",
-				"esbuild": "0.23.0",
-				"fast-glob": "3.3.2",
-				"fs-extra": "11.2.0",
-				"hookable": "5.5.3",
-				"mime": "4.0.4",
-				"octokit": "4.0.2",
-				"radash": "12.1.0",
-				"replace-in-file": "8.1.0",
-				"std-env": "3.7.0",
-				"update-notifier": "7.1.0",
-				"web-ext": "8.2.0"
+				"@commander-js/extra-typings": "^12.1.0",
+				"@gitee/typescript-sdk-v5": "^5.4.85",
+				"@inquirer/prompts": "^5.5.0",
+				"bumpp": "^9.6.1",
+				"c12": "^1.11.2",
+				"chalk": "^5.3.0",
+				"chokidar": "^3.6.0",
+				"commander": "^12.1.0",
+				"conventional-changelog": "^6.0.0",
+				"es-toolkit": "^1.22.0",
+				"esbuild": "^0.23.1",
+				"fs-extra": "^11.2.0",
+				"globby": "^14.0.2",
+				"hookable": "^5.5.3",
+				"mime": "^4.0.4",
+				"octokit": "^4.0.2",
+				"replace-in-file": "^8.2.0",
+				"std-env": "^3.7.0",
+				"update-notifier": "^7.3.1",
+				"web-ext": "^8.3.0"
 			},
 			"bin": {
 				"zotero-plugin": "dist/cli.mjs"
@@ -12976,13 +11847,14 @@
 			}
 		},
 		"node_modules/zotero-plugin-scaffold/node_modules/@esbuild/win32-x64": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
-			"integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+			"integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -12991,13 +11863,76 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/zotero-plugin-scaffold/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/boxen": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+			"integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-align": "^3.0.1",
+				"camelcase": "^8.0.0",
+				"chalk": "^5.3.0",
+				"cli-boxes": "^3.0.0",
+				"string-width": "^7.2.0",
+				"type-fest": "^4.21.0",
+				"widest-line": "^5.0.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/zotero-plugin-scaffold/node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/camelcase": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/zotero-plugin-scaffold/node_modules/chalk": {
@@ -13005,6 +11940,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
 			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -13012,12 +11948,55 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/zotero-plugin-scaffold/node_modules/configstore": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.0.0.tgz",
+			"integrity": "sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"atomically": "^2.0.3",
+				"dot-prop": "^9.0.0",
+				"graceful-fs": "^4.2.11",
+				"xdg-basedir": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/yeoman/configstore?sponsor=1"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/dot-prop": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+			"integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^4.18.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/zotero-plugin-scaffold/node_modules/esbuild": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
-			"integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+			"integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -13025,30 +12004,30 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.23.0",
-				"@esbuild/android-arm": "0.23.0",
-				"@esbuild/android-arm64": "0.23.0",
-				"@esbuild/android-x64": "0.23.0",
-				"@esbuild/darwin-arm64": "0.23.0",
-				"@esbuild/darwin-x64": "0.23.0",
-				"@esbuild/freebsd-arm64": "0.23.0",
-				"@esbuild/freebsd-x64": "0.23.0",
-				"@esbuild/linux-arm": "0.23.0",
-				"@esbuild/linux-arm64": "0.23.0",
-				"@esbuild/linux-ia32": "0.23.0",
-				"@esbuild/linux-loong64": "0.23.0",
-				"@esbuild/linux-mips64el": "0.23.0",
-				"@esbuild/linux-ppc64": "0.23.0",
-				"@esbuild/linux-riscv64": "0.23.0",
-				"@esbuild/linux-s390x": "0.23.0",
-				"@esbuild/linux-x64": "0.23.0",
-				"@esbuild/netbsd-x64": "0.23.0",
-				"@esbuild/openbsd-arm64": "0.23.0",
-				"@esbuild/openbsd-x64": "0.23.0",
-				"@esbuild/sunos-x64": "0.23.0",
-				"@esbuild/win32-arm64": "0.23.0",
-				"@esbuild/win32-ia32": "0.23.0",
-				"@esbuild/win32-x64": "0.23.0"
+				"@esbuild/aix-ppc64": "0.23.1",
+				"@esbuild/android-arm": "0.23.1",
+				"@esbuild/android-arm64": "0.23.1",
+				"@esbuild/android-x64": "0.23.1",
+				"@esbuild/darwin-arm64": "0.23.1",
+				"@esbuild/darwin-x64": "0.23.1",
+				"@esbuild/freebsd-arm64": "0.23.1",
+				"@esbuild/freebsd-x64": "0.23.1",
+				"@esbuild/linux-arm": "0.23.1",
+				"@esbuild/linux-arm64": "0.23.1",
+				"@esbuild/linux-ia32": "0.23.1",
+				"@esbuild/linux-loong64": "0.23.1",
+				"@esbuild/linux-mips64el": "0.23.1",
+				"@esbuild/linux-ppc64": "0.23.1",
+				"@esbuild/linux-riscv64": "0.23.1",
+				"@esbuild/linux-s390x": "0.23.1",
+				"@esbuild/linux-x64": "0.23.1",
+				"@esbuild/netbsd-x64": "0.23.1",
+				"@esbuild/openbsd-arm64": "0.23.1",
+				"@esbuild/openbsd-x64": "0.23.1",
+				"@esbuild/sunos-x64": "0.23.1",
+				"@esbuild/win32-arm64": "0.23.1",
+				"@esbuild/win32-ia32": "0.23.1",
+				"@esbuild/win32-x64": "0.23.1"
 			}
 		},
 		"node_modules/zotero-plugin-scaffold/node_modules/glob": {
@@ -13056,6 +12035,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
 			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
 				"jackspeak": "^3.1.2",
@@ -13071,14 +12051,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/zotero-plugin-scaffold/node_modules/is-installed-globally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
-			"integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+		"node_modules/zotero-plugin-scaffold/node_modules/globby": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"global-directory": "^4.0.1",
-				"is-path-inside": "^4.0.0"
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
+				"ignore": "^5.2.4",
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -13087,25 +12072,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/zotero-plugin-scaffold/node_modules/is-path-inside": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+		"node_modules/zotero-plugin-scaffold/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
+			"license": "ISC"
 		},
-		"node_modules/zotero-plugin-scaffold/node_modules/latest-version": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
-			"integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+		"node_modules/zotero-plugin-scaffold/node_modules/is-in-ci": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+			"integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
 			"dev": true,
-			"dependencies": {
-				"package-json": "^10.0.0"
+			"license": "MIT",
+			"bin": {
+				"is-in-ci": "cli.js"
 			},
 			"engines": {
 				"node": ">=18"
@@ -13119,6 +12100,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -13134,33 +12116,30 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
 			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/zotero-plugin-scaffold/node_modules/package-json": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
-			"integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+		"node_modules/zotero-plugin-scaffold/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
 			"dev": true,
-			"dependencies": {
-				"ky": "^1.2.0",
-				"registry-auth-token": "^5.0.2",
-				"registry-url": "^6.0.1",
-				"semver": "^7.6.0"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/zotero-plugin-scaffold/node_modules/replace-in-file": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-8.1.0.tgz",
-			"integrity": "sha512-ySYfKDH6uFVC4Wt6DcZ2UX0UMCqE7xhWGVqje/15WFVwHxnel1gdZjV8nOW9Nms6h/yQE2MWyeIToeqFLZkp4w==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-8.2.0.tgz",
+			"integrity": "sha512-hMsQtdYHwWviQT5ZbNsgfu0WuCiNlcUSnnD+aHAL081kbU9dPkPocDaHlDvAHKydTWWpx1apfcEcmvIyQk3CpQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^5.3.0",
 				"glob": "^10.4.2",
@@ -13178,6 +12157,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
 			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -13185,23 +12165,82 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/zotero-plugin-scaffold/node_modules/update-notifier": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.1.0.tgz",
-			"integrity": "sha512-8SV3rIqVY6EFC1WxH6L0j55s0MO79MFBS1pivmInRJg3pCEDgWHBj1Q6XByTtCLOZIFA0f6zoG9ZWf2Ks9lvTA==",
+		"node_modules/zotero-plugin-scaffold/node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"boxen": "^7.1.1",
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/type-fest": {
+			"version": "4.26.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+			"integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/update-notifier": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+			"integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boxen": "^8.0.1",
 				"chalk": "^5.3.0",
-				"configstore": "^6.0.0",
-				"import-lazy": "^4.0.0",
-				"is-in-ci": "^0.1.0",
+				"configstore": "^7.0.0",
+				"is-in-ci": "^1.0.0",
 				"is-installed-globally": "^1.0.0",
 				"is-npm": "^6.0.0",
 				"latest-version": "^9.0.0",
 				"pupa": "^3.1.0",
-				"semver": "^7.6.2",
-				"semver-diff": "^4.0.0",
+				"semver": "^7.6.3",
 				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
@@ -13211,18 +12250,57 @@
 				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
 			}
 		},
-		"node_modules/zotero-plugin-toolkit": {
-			"version": "2.3.37",
-			"resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-2.3.37.tgz",
-			"integrity": "sha512-C1e9o+pWR8vPJQaGpHPDKEsWcTJwjef90vX+kQQ6aDlXYNomhtHNXHmweIQWoufNQz26wQQkFFU1zkvIQ4Ff6A==",
+		"node_modules/zotero-plugin-scaffold/node_modules/widest-line": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+			"integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"zotero-types": "^2.0.3"
+				"string-width": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zotero-plugin-scaffold/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/zotero-plugin-toolkit": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-4.0.6.tgz",
+			"integrity": "sha512-juxIrSrUYTxk+efQJAH7OpfQHSboErMd0Ygu2eZs/xKA1177XlCYhe0sdxlTxI8Y/4UGtRwLicThUddaOfArMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"zotero-types": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/zotero-types": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/zotero-types/-/zotero-types-2.1.0.tgz",
-			"integrity": "sha512-PY3uAJCuce5nquAgPxJ5LnZ05XR7J7LsKwfNt2xzsWAaWJNce0HAlea7Wy/OSWmuuNGKi6wRPIOD0y8quraVOg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/zotero-types/-/zotero-types-2.2.0.tgz",
+			"integrity": "sha512-Th63hgO+OhWgCy3rSQOSTnEIuhK5gPUsG/No8jqxSGKKksd7b6DQ/V7glmdXieoZEJpzoV0bWyZEQflWU5obHQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/bluebird": "^3.5.42",
 				"@types/react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	},
 	"homepage": "https://github.com/Dominic-DallOsto/zotero-reading-list",
 	"dependencies": {
-		"zotero-plugin-toolkit": "^2.3.37"
+		"zotero-plugin-toolkit": "^4.0.6"
 	},
 	"devDependencies": {
 		"@types/node": "^20.10.4",
@@ -44,11 +44,11 @@
 		"eslint": "^8.55.0",
 		"eslint-config-prettier": "^9.1.0",
 		"prettier": "^3.1.1",
-		"release-it": "^17.0.1",
+		"release-it": "^17.7.0",
 		"replace-in-file": "^7.0.2",
 		"typescript": "^5.3.3",
-		"zotero-plugin-scaffold": "^0.0.33",
-		"zotero-types": "^2.1.0"
+		"zotero-plugin-scaffold": "^0.1.6",
+		"zotero-types": "^2.2.0"
 	},
 	"eslintConfig": {
 		"env": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zotero-reading-list",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Keep track of whether you've read items in Zotero",
 	"config": {
 		"addonName": "Zotero Reading List",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BasicTool } from "zotero-plugin-toolkit/dist/basic";
+import { BasicTool } from "zotero-plugin-toolkit";
 import Addon from "./addon";
 import { config } from "../package.json";
 

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -371,11 +371,11 @@ export default class ZoteroReadingList {
 			image: `chrome://${config.addonRef}/content/icons/favicon.png`,
 			defaultXUL: true,
 		};
-		ztoolkit.PreferencePane.register(prefOptions);
+		void Zotero.PreferencePanes.register(prefOptions);
 	}
 
 	removePreferenceMenu() {
-		ztoolkit.PreferencePane.unregister(config.addonID);
+		Zotero.PreferencePanes.unregister(config.addonID);
 	}
 
 	addRightClickMenuPopup() {

--- a/src/utils/ztoolkit.ts
+++ b/src/utils/ztoolkit.ts
@@ -1,15 +1,22 @@
-import ZoteroToolkit from "zotero-plugin-toolkit";
+import {
+	BasicTool,
+	makeHelperTool,
+	MenuManager,
+	ProgressWindowHelper,
+	UITool,
+	unregister,
+} from "zotero-plugin-toolkit";
 import { config } from "../../package.json";
 
 export { createZToolkit };
 
 function createZToolkit() {
-	const _ztoolkit = new ZoteroToolkit();
+	// const _ztoolkit = new ZoteroToolkit();
 	/**
 	 * Alternatively, import toolkit modules you use to minify the plugin size.
 	 * You can add the modules under the `MyToolkit` class below and uncomment the following line.
 	 */
-	// const _ztoolkit = new MyToolkit();
+	const _ztoolkit = new MyToolkit();
 	initZToolkit(_ztoolkit);
 	return _ztoolkit;
 }
@@ -31,18 +38,16 @@ function initZToolkit(_ztoolkit: ReturnType<typeof createZToolkit>) {
 	);
 }
 
-import { BasicTool, unregister } from "zotero-plugin-toolkit/dist/basic";
-import { UITool } from "zotero-plugin-toolkit/dist/tools/ui";
-import { PreferencePaneManager } from "zotero-plugin-toolkit/dist/managers/preferencePane";
-
 class MyToolkit extends BasicTool {
 	UI: UITool;
-	PreferencePane: PreferencePaneManager;
+	Menu: MenuManager;
+	ProgressWindow: typeof ProgressWindowHelper;
 
 	constructor() {
 		super();
 		this.UI = new UITool(this);
-		this.PreferencePane = new PreferencePaneManager(this);
+		this.Menu = new MenuManager(this);
+		this.ProgressWindow = makeHelperTool(ProgressWindowHelper, this);
 	}
 
 	unregisterAll() {


### PR DESCRIPTION
Fixes #58

Somehow installing multiple plugins that used zotero-plugin-toolkit was causing conflicts and the plugins wouldn't run unless all others were disabled.

Upgrading zotero-plugin-toolkit to version 4 should fix this.